### PR TITLE
Add global server URL constant to mobile app

### DIFF
--- a/mobile/config.js
+++ b/mobile/config.js
@@ -1,0 +1,1 @@
+export const SERVER_URL = 'http://78.137.7.91:20004';

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, Text } from 'react-native';
+import { SERVER_URL } from '../config';
 
 export default function LoginScreen({ navigation, setToken }) {
   const [email, setEmail] = useState('');
@@ -8,7 +9,7 @@ export default function LoginScreen({ navigation, setToken }) {
 
   const login = async () => {
     try {
-      const res = await fetch('http://localhost:3000/auth/login', {
+      const res = await fetch(`${SERVER_URL}/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/mobile/screens/OrdersScreen.js
+++ b/mobile/screens/OrdersScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList } from 'react-native';
+import { SERVER_URL } from '../config';
 
 export default function OrdersScreen({ token }) {
   const [orders, setOrders] = useState([]);
@@ -7,7 +8,7 @@ export default function OrdersScreen({ token }) {
   useEffect(() => {
     const fetchOrders = async () => {
       try {
-        const res = await fetch('http://localhost:3000/orders', {
+        const res = await fetch(`${SERVER_URL}/orders`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (res.ok) {


### PR DESCRIPTION
## Summary
- centralize server URL
- use the new constant in Login and Orders screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d95ed5f1c83248d4b70eefcfda360