### PR TITLE
Fix Expo SDK version mismatch

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Vango",
     "slug": "vango-mobile",
     "version": "1.0.0",
-    "sdkVersion": "50.0.0",
+    "sdkVersion": "53.0.0",
     "platforms": ["ios", "android", "web"],
     "jsEngine": "hermes"
   }


### PR DESCRIPTION
## Summary
- align mobile `sdkVersion` with Expo 53

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684d9842023c832481acaa29d2767aea