### PR TITLE
Add React Native mobile app skeleton

### DIFF
--- a/mobile-app/.gitignore
+++ b/mobile-app/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.expo
+.idea

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './src/screens/LoginScreen';
+import RegisterScreen from './src/screens/RegisterScreen';
+import OrderListScreen from './src/screens/OrderListScreen';
+import OrderDetailScreen from './src/screens/OrderDetailScreen';
+import CreateOrderScreen from './src/screens/CreateOrderScreen';
+import BalanceScreen from './src/screens/BalanceScreen';
+import AdminScreen from './src/screens/AdminScreen';
+import AnalyticsScreen from './src/screens/AnalyticsScreen';
+import RateUserScreen from './src/screens/RateUserScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Register" component={RegisterScreen} />
+        <Stack.Screen name="Orders" component={OrderListScreen} />
+        <Stack.Screen name="OrderDetail" component={OrderDetailScreen} />
+        <Stack.Screen name="CreateOrder" component={CreateOrderScreen} />
+        <Stack.Screen name="Balance" component={BalanceScreen} />
+        <Stack.Screen name="Admin" component={AdminScreen} />
+        <Stack.Screen name="Analytics" component={AnalyticsScreen} />
+        <Stack.Screen name="RateUser" component={RateUserScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "Vango Logistics",
+    "slug": "vango-mobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android", "web"],
+    "sdkVersion": "50.0.0",
+    "jsEngine": "hermes",
+    "entryPoint": "./App.js"
+  }
+}

--- a/mobile-app/babel.config.js
+++ b/mobile-app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mobile-app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-safe-area-context": "4.8.0",
+    "react-native-screens": "^3.22.0",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12"
+  }
+}

--- a/mobile-app/src/api.js
+++ b/mobile-app/src/api.js
@@ -1,0 +1,13 @@
+export const API_URL = 'http://localhost:3000/api';
+
+export async function apiFetch(path, options = {}) {
+  const res = await fetch(`${API_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(error);
+  }
+  return res.json();
+}

--- a/mobile-app/src/screens/AdminScreen.js
+++ b/mobile-app/src/screens/AdminScreen.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function AdminScreen({ route }) {
+  const { token } = route.params;
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const data = await apiFetch('/admin/users', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setUsers(data);
+    }
+    load();
+  }, []);
+
+  async function block(id) {
+    await apiFetch(`/admin/users/${id}/block`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    });
+  }
+
+  function renderItem({ item }) {
+    return (
+      <View style={styles.item}>
+        <Text>{item.name} ({item.role})</Text>
+        {item.role === 'DRIVER' && (
+          <Button title={item.blocked ? 'Unblock' : 'Block'} onPress={() => block(item.id)} />
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <FlatList data={users} renderItem={renderItem} keyExtractor={u => u.id.toString()} />
+  );
+}
+
+const styles = StyleSheet.create({
+  item: { padding: 12, borderBottomWidth: 1 }
+});

--- a/mobile-app/src/screens/AnalyticsScreen.js
+++ b/mobile-app/src/screens/AnalyticsScreen.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function AnalyticsScreen({ route }) {
+  const { token } = route.params;
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await apiFetch('/admin/analytics', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setData(res);
+    }
+    load();
+  }, []);
+
+  if (!data) {
+    return <Text>Loading...</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Average Price: {data.avgPrice}</Text>
+      <Text>Delivered Orders: {data.deliveredCount}</Text>
+      <Text>Average Delivery Time: {data.avgTime}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 }
+});

--- a/mobile-app/src/screens/BalanceScreen.js
+++ b/mobile-app/src/screens/BalanceScreen.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function BalanceScreen({ route }) {
+  const { token } = route.params;
+  const [balance, setBalance] = useState(0);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiFetch('/finance/balance', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setBalance(data.balance);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    load();
+  }, []);
+
+  async function withdraw() {
+    await apiFetch('/finance/withdraw', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ amount: balance })
+    });
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Balance: {balance}</Text>
+      <Button title="Withdraw" onPress={withdraw} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+});

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function CreateOrderScreen({ route, navigation }) {
+  const { token } = route.params;
+  const [pickupLocation, setPickup] = useState('');
+  const [dropoffLocation, setDropoff] = useState('');
+  const [price, setPrice] = useState('');
+
+  async function create() {
+    try {
+      await apiFetch('/orders', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ pickupLocation, dropoffLocation, price })
+      });
+      navigation.navigate('Orders', { token });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Pickup location</Text>
+      <TextInput style={styles.input} value={pickupLocation} onChangeText={setPickup} />
+      <Text>Dropoff location</Text>
+      <TextInput style={styles.input} value={dropoffLocation} onChangeText={setDropoff} />
+      <Text>Price</Text>
+      <TextInput style={styles.input} value={price} onChangeText={setPrice} keyboardType="numeric" />
+      <Button title="Create" onPress={create} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  input: { borderWidth: 1, padding: 8, marginVertical: 4 }
+});

--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  async function handleLogin() {
+    try {
+      const data = await apiFetch('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password })
+      });
+      navigation.navigate('Orders', { token: data.token });
+    } catch (err) {
+      setError('Login failed');
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Email</Text>
+      <TextInput style={styles.input} value={email} onChangeText={setEmail} autoCapitalize="none" />
+      <Text style={styles.label}>Password</Text>
+      <TextInput style={styles.input} value={password} onChangeText={setPassword} secureTextEntry />
+      {error && <Text style={styles.error}>{error}</Text>}
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Register" onPress={() => navigation.navigate('Register')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  label: { marginTop: 8 },
+  input: { borderWidth: 1, padding: 8, borderRadius: 4 },
+  error: { color: 'red', marginTop: 8 }
+});

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function OrderDetailScreen({ route, navigation }) {
+  const { order, token } = route.params;
+
+  async function accept() {
+    try {
+      await apiFetch(`/orders/${order.id}/accept`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      navigation.navigate('Orders', { token });
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Pickup: {order.pickupLocation}</Text>
+      <Text>Dropoff: {order.dropoffLocation}</Text>
+      <Text>Price: {order.price}</Text>
+      <Button title="Accept" onPress={accept} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 }
+});

--- a/mobile-app/src/screens/OrderListScreen.js
+++ b/mobile-app/src/screens/OrderListScreen.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function OrderListScreen({ navigation, route }) {
+  const { token } = route.params;
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiFetch('/orders', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setOrders(data.available);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    load();
+  }, []);
+
+  function renderItem({ item }) {
+    return (
+      <TouchableOpacity onPress={() => navigation.navigate('OrderDetail', { order: item, token })}>
+        <View style={styles.item}>
+          <Text>{item.pickupLocation} -> {item.dropoffLocation}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList data={orders} renderItem={renderItem} keyExtractor={o => o.id.toString()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  item: { padding: 12, borderBottomWidth: 1 }
+});

--- a/mobile-app/src/screens/RateUserScreen.js
+++ b/mobile-app/src/screens/RateUserScreen.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function RateUserScreen({ route }) {
+  const { token, toUserId, orderId } = route.params;
+  const [rating, setRating] = useState('5');
+  const [comment, setComment] = useState('');
+
+  async function submit() {
+    await apiFetch('/ratings', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ toUserId, orderId, rating: parseFloat(rating), comment })
+    });
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>Rating</Text>
+      <TextInput style={styles.input} value={rating} onChangeText={setRating} keyboardType="numeric" />
+      <Text>Comment</Text>
+      <TextInput style={styles.input} value={comment} onChangeText={setComment} />
+      <Button title="Submit" onPress={submit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  input: { borderWidth: 1, padding: 8, marginVertical: 4 }
+});

--- a/mobile-app/src/screens/RegisterScreen.js
+++ b/mobile-app/src/screens/RegisterScreen.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { apiFetch } from '../api';
+
+export default function RegisterScreen({ navigation }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('CUSTOMER');
+  const [city, setCity] = useState('');
+  const [error, setError] = useState(null);
+
+  async function handleRegister() {
+    try {
+      await apiFetch('/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({ name, email, password, role, city })
+      });
+      navigation.navigate('Login');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Name</Text>
+      <TextInput style={styles.input} value={name} onChangeText={setName} />
+      <Text style={styles.label}>Email</Text>
+      <TextInput style={styles.input} value={email} onChangeText={setEmail} autoCapitalize="none" />
+      <Text style={styles.label}>Password</Text>
+      <TextInput style={styles.input} value={password} onChangeText={setPassword} secureTextEntry />
+      <Text style={styles.label}>Role (DRIVER or CUSTOMER)</Text>
+      <TextInput style={styles.input} value={role} onChangeText={setRole} />
+      <Text style={styles.label}>City</Text>
+      <TextInput style={styles.input} value={city} onChangeText={setCity} />
+      {error && <Text style={styles.error}>{error}</Text>}
+      <Button title="Register" onPress={handleRegister} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  label: { marginTop: 8 },
+  input: { borderWidth: 1, padding: 8, borderRadius: 4 },
+  error: { color: 'red', marginTop: 8 }
+});


### PR DESCRIPTION
## Summary
- add Expo-based mobile app with navigation
- include login, register, orders, order details, create order, balance, admin, analytics, and rating screens
- add API helper for backend communication

## Testing
- `npm run dev` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6850126e121c8324a0d3a0506c818e5e