### PR TITLE
Add simple home menu screen

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -10,6 +10,7 @@ import BalanceScreen from './src/screens/BalanceScreen';
 import AdminScreen from './src/screens/AdminScreen';
 import AnalyticsScreen from './src/screens/AnalyticsScreen';
 import RateUserScreen from './src/screens/RateUserScreen';
+import HomeScreen from './src/screens/HomeScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -19,6 +20,7 @@ export default function App() {
       <Stack.Navigator initialRouteName="Login">
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Register" component={RegisterScreen} />
+        <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Orders" component={OrderListScreen} />
         <Stack.Screen name="OrderDetail" component={OrderDetailScreen} />
         <Stack.Screen name="CreateOrder" component={CreateOrderScreen} />

--- a/mobile-app/src/screens/HomeScreen.js
+++ b/mobile-app/src/screens/HomeScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ navigation, route }) {
+  const { token } = route.params;
+  return (
+    <View style={styles.container}>
+      <Button title="Orders" onPress={() => navigation.navigate('Orders', { token })} />
+      <Button title="Create Order" onPress={() => navigation.navigate('CreateOrder', { token })} />
+      <Button title="Balance" onPress={() => navigation.navigate('Balance', { token })} />
+      <Button title="Admin" onPress={() => navigation.navigate('Admin', { token })} />
+      <Button title="Analytics" onPress={() => navigation.navigate('Analytics', { token })} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', gap: 12, padding: 16 }
+});

--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -13,7 +13,7 @@ export default function LoginScreen({ navigation }) {
         method: 'POST',
         body: JSON.stringify({ email, password })
       });
-      navigation.navigate('Orders', { token: data.token });
+      navigation.navigate('Home', { token: data.token });
     } catch (err) {
       setError('Login failed');
     }


### PR DESCRIPTION
## Summary
- create a HomeScreen with buttons leading to different features
- wire HomeScreen into the stack navigator
- navigate to HomeScreen after logging in

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68501bbd38e083248e48c70c181312e9