### PR TITLE
Redesign login/registration and unify roles

### DIFF
--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
 import { apiFetch } from '../api';
 
 export default function LoginScreen({ navigation }) {
@@ -13,28 +13,36 @@ export default function LoginScreen({ navigation }) {
         method: 'POST',
         body: JSON.stringify({ email, password })
       });
+      Alert.alert('Успіх', 'Вхід виконано');
       navigation.navigate('Home', { token: data.token });
     } catch (err) {
-      setError('Login failed');
+      const msg = err.message || 'Помилка входу';
+      setError(msg);
+      Alert.alert('Помилка', msg);
     }
   }
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Email</Text>
+      <Text style={styles.label}>Електронна пошта</Text>
       <TextInput style={styles.input} value={email} onChangeText={setEmail} autoCapitalize="none" />
-      <Text style={styles.label}>Password</Text>
+      <Text style={styles.label}>Пароль</Text>
       <TextInput style={styles.input} value={password} onChangeText={setPassword} secureTextEntry />
       {error && <Text style={styles.error}>{error}</Text>}
-      <Button title="Login" onPress={handleLogin} />
-      <Button title="Register" onPress={() => navigation.navigate('Register')} />
+      <View style={styles.buttonContainer}>
+        <Button title="Увійти" color="#2ecc71" onPress={handleLogin} />
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button title="Реєстрація" color="#e67e22" onPress={() => navigation.navigate('Register')} />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16 },
-  label: { marginTop: 8 },
-  input: { borderWidth: 1, padding: 8, borderRadius: 4 },
-  error: { color: 'red', marginTop: 8 }
+  container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  label: { marginTop: 8, color: '#e67e22' },
+  input: { borderWidth: 1, borderColor: '#2ecc71', padding: 8, borderRadius: 4 },
+  error: { color: 'red', marginTop: 8 },
+  buttonContainer: { marginTop: 8 }
 });

--- a/mobile-app/src/screens/RegisterScreen.js
+++ b/mobile-app/src/screens/RegisterScreen.js
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
 import { apiFetch } from '../api';
 
 export default function RegisterScreen({ navigation }) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [role, setRole] = useState('CUSTOMER');
   const [city, setCity] = useState('');
   const [error, setError] = useState(null);
 
@@ -14,35 +13,40 @@ export default function RegisterScreen({ navigation }) {
     try {
       await apiFetch('/auth/register', {
         method: 'POST',
-        body: JSON.stringify({ name, email, password, role, city })
+        body: JSON.stringify({ name, email, password, city })
       });
-      navigation.navigate('Login');
+      Alert.alert('Успіх', 'Реєстрація успішна', [
+        { text: 'OK', onPress: () => navigation.navigate('Login') }
+      ]);
     } catch (err) {
-      setError('Registration failed');
+      const msg = err.message || 'Помилка реєстрації';
+      setError(msg);
+      Alert.alert('Помилка', msg);
     }
   }
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Name</Text>
+      <Text style={styles.label}>Ім\'я</Text>
       <TextInput style={styles.input} value={name} onChangeText={setName} />
-      <Text style={styles.label}>Email</Text>
+      <Text style={styles.label}>Електронна пошта</Text>
       <TextInput style={styles.input} value={email} onChangeText={setEmail} autoCapitalize="none" />
-      <Text style={styles.label}>Password</Text>
+      <Text style={styles.label}>Пароль</Text>
       <TextInput style={styles.input} value={password} onChangeText={setPassword} secureTextEntry />
-      <Text style={styles.label}>Role (DRIVER or CUSTOMER)</Text>
-      <TextInput style={styles.input} value={role} onChangeText={setRole} />
-      <Text style={styles.label}>City</Text>
+      <Text style={styles.label}>Місто</Text>
       <TextInput style={styles.input} value={city} onChangeText={setCity} />
       {error && <Text style={styles.error}>{error}</Text>}
-      <Button title="Register" onPress={handleRegister} />
+      <View style={styles.buttonContainer}>
+        <Button title="Зареєструватися" color="#2ecc71" onPress={handleRegister} />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16 },
-  label: { marginTop: 8 },
-  input: { borderWidth: 1, padding: 8, borderRadius: 4 },
-  error: { color: 'red', marginTop: 8 }
+  container: { flex: 1, padding: 16, backgroundColor: '#fff' },
+  label: { marginTop: 8, color: '#e67e22' },
+  input: { borderWidth: 1, borderColor: '#2ecc71', padding: 8, borderRadius: 4 },
+  error: { color: 'red', marginTop: 8 },
+  buttonContainer: { marginTop: 16 }
 });

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -10,7 +10,7 @@ async function listUsers(_req, res) {
 async function blockDriver(req, res) {
   const { id } = req.params;
   const user = await User.findByPk(id);
-  if (!user || user.role !== 'DRIVER') {
+  if (!user || (user.role !== 'DRIVER' && user.role !== 'BOTH')) {
     res.status(404).json({ message: 'Driver not found' });
     return;
   }
@@ -22,7 +22,7 @@ async function blockDriver(req, res) {
 async function unblockDriver(req, res) {
   const { id } = req.params;
   const user = await User.findByPk(id);
-  if (!user || user.role !== 'DRIVER') {
+  if (!user || (user.role !== 'DRIVER' && user.role !== 'BOTH')) {
     res.status(404).json({ message: 'Driver not found' });
     return;
   }

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -4,10 +4,10 @@ const User = require('../models/user');
 const { JWT_SECRET } = require('../config');
 
 async function register(req, res) {
-  const { name, email, password, role, city } = req.body;
+  const { name, email, password, city } = req.body;
   try {
     const hashed = await bcrypt.hash(password, 10);
-    const user = await User.create({ name, email, password: hashed, role, city });
+    const user = await User.create({ name, email, password: hashed, city });
     res.json(user);
   } catch (err) {
     res.status(400).json({ message: 'Registration failed', error: err });

--- a/src/controllers/favoriteController.js
+++ b/src/controllers/favoriteController.js
@@ -5,7 +5,7 @@ async function addFavorite(req, res) {
   const driverId = req.params.driverId;
   try {
     const driver = await User.findByPk(driverId);
-    if (!driver || driver.role !== 'DRIVER') {
+    if (!driver || (driver.role !== 'DRIVER' && driver.role !== 'BOTH')) {
       return res.status(404).json({ message: 'Driver not found' });
     }
     await Favorite.findOrCreate({ where: { customerId: req.user.id, driverId } });

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -34,11 +34,16 @@ async function listAvailableOrders(req, res) {
 }
 
 async function listMyOrders(req, res) {
-  const where = {};
+  const { Op } = require('sequelize');
+  let where = {};
   if (req.user.role === 'CUSTOMER') {
     where.customerId = req.user.id;
   } else if (req.user.role === 'DRIVER') {
     where.driverId = req.user.id;
+  } else if (req.user.role === 'BOTH') {
+    where = {
+      [Op.or]: [{ customerId: req.user.id }, { driverId: req.user.id }],
+    };
   }
   const orders = await Order.findAll({ where });
   res.json(orders);

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -20,10 +20,19 @@ async function authenticate(req, res, next) {
 
 function authorize(roles) {
   return (req, res, next) => {
-    if (!req.user || !roles.includes(req.user.role)) {
+    if (!req.user) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    next();
+    if (roles.includes(req.user.role)) {
+      return next();
+    }
+    if (
+      req.user.role === 'BOTH' &&
+      (roles.includes('DRIVER') || roles.includes('CUSTOMER'))
+    ) {
+      return next();
+    }
+    return res.status(403).json({ message: 'Forbidden' });
   };
 }
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -5,6 +5,7 @@ const UserRole = {
   DRIVER: 'DRIVER',
   CUSTOMER: 'CUSTOMER',
   ADMIN: 'ADMIN',
+  BOTH: 'BOTH',
 };
 
 class User extends Model {}
@@ -19,7 +20,11 @@ User.init(
     name: { type: DataTypes.STRING, allowNull: false },
     email: { type: DataTypes.STRING, allowNull: false, unique: true },
     password: { type: DataTypes.STRING, allowNull: false },
-    role: { type: DataTypes.ENUM(...Object.values(UserRole)), allowNull: false },
+    role: {
+      type: DataTypes.ENUM(...Object.values(UserRole)),
+      allowNull: false,
+      defaultValue: UserRole.BOTH,
+    },
     rating: { type: DataTypes.FLOAT, defaultValue: 5 },
     blocked: { type: DataTypes.BOOLEAN, defaultValue: false },
     city: { type: DataTypes.STRING },

--- a/src/seed.js
+++ b/src/seed.js
@@ -6,8 +6,8 @@ const Order = require('./models/order');
 async function seed() {
   await db.sync({ force: true });
 
-  const customer = await User.create({ name: 'Alice', email: 'alice@example.com', password: 'pass', role: UserRole.CUSTOMER, city: 'NYC' });
-  const driver = await User.create({ name: 'Bob', email: 'bob@example.com', password: 'pass', role: UserRole.DRIVER, city: 'NYC' });
+  const customer = await User.create({ name: 'Alice', email: 'alice@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC' });
+  const driver = await User.create({ name: 'Bob', email: 'bob@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC' });
   await User.create({ name: 'Admin', email: 'admin@example.com', password: 'admin', role: UserRole.ADMIN });
 
   await Order.create({


### PR DESCRIPTION
## Summary
- redesign Login and Register screens with Ukrainian UI texts and green/orange styling
- show alerts for success and error feedback
- remove explicit role selection during registration
- introduce `BOTH` role on the backend and allow it as driver and customer
- adjust authorization middleware and controllers for new role
- update seed data

## Testing
- `npm test` (fails: Missing script)
- `npm run --silent seed` (fails: TypeError in sequelize config)


------
https://chatgpt.com/codex/tasks/task_e_6853dc91ce1c8324b3ddda6736add12e