### PR TITLE
Fix navigation reset and persist role

### DIFF
--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -12,7 +12,7 @@ import { useAuth } from '../AuthContext';
 
 export default function LoginScreen({ navigation }) {
   const toast = useToast();
-  const { login, role } = useAuth();
+  const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
@@ -37,13 +37,9 @@ export default function LoginScreen({ navigation }) {
         method: 'POST',
         body: JSON.stringify({ email, password }),
       });
-      await login(data.token);
+      await login(data.token, data.role);
       toast.show('Вхід виконано');
-      if (role) {
-        navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
-      } else {
-        navigation.reset({ index: 0, routes: [{ name: 'Role' }] });
-      }
+      // Navigation is handled by root navigator based on auth state
     } catch (err) {
       const msg = err.message || 'Помилка входу';
       setError(msg);

--- a/mobile-app/src/screens/RoleScreen.js
+++ b/mobile-app/src/screens/RoleScreen.js
@@ -3,12 +3,11 @@ import { View, StyleSheet } from 'react-native';
 import AppButton from '../components/AppButton';
 import { useAuth } from '../AuthContext';
 
-export default function RoleScreen({ navigation }) {
+export default function RoleScreen() {
   const { selectRole } = useAuth();
 
   async function choose(r) {
     await selectRole(r);
-    navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
   }
 
   return (

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,8 +1,11 @@
 const { Router } = require('express');
-const { register, login } = require('../controllers/authController');
+const { register, login, profile, updateRole } = require('../controllers/authController');
+const { authenticate } = require('../middlewares/auth');
 
 const router = Router();
 router.post('/register', register);
 router.post('/login', login);
+router.get('/me', authenticate, profile);
+router.put('/role', authenticate, updateRole);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- store user role on the server and return it from login
- expose `/api/auth/me` and `/api/auth/role` endpoints
- fetch role on startup and when logging in
- update role selection to send to backend
- rely on auth state for navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb3ee4cc8324898f3006421ef4f5