### PR TITLE
Implement role switcher and improved order creation

### DIFF
--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^7.1.11",
         "@react-navigation/native-stack": "^7.3.16",
         "expo": "~53.0.11",
+        "expo-image-picker": "^16.1.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.3"
@@ -3872,6 +3873,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -16,7 +16,8 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.3"
+    "react-native": "0.79.3",
+    "expo-image-picker": "^16.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -1,11 +1,31 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  Alert,
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { apiFetch } from '../api';
 
 export default function CreateOrderScreen({ route, navigation }) {
   const { token } = route.params;
-  const [pickupLocation, setPickup] = useState('');
-  const [dropoffLocation, setDropoff] = useState('');
+  const [pickupQuery, setPickupQuery] = useState('');
+  const [pickup, setPickup] = useState(null);
+  const [pickupSuggestions, setPickupSuggestions] = useState([]);
+  const [dropoffQuery, setDropoffQuery] = useState('');
+  const [dropoff, setDropoff] = useState(null);
+  const [dropoffSuggestions, setDropoffSuggestions] = useState([]);
+  const [length, setLength] = useState('');
+  const [width, setWidth] = useState('');
+  const [height, setHeight] = useState('');
+  const [photo, setPhoto] = useState(null);
+  const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
 
   async function create() {
@@ -13,28 +33,152 @@ export default function CreateOrderScreen({ route, navigation }) {
       await apiFetch('/orders', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ pickupLocation, dropoffLocation, price })
+        body: JSON.stringify({
+          pickupLocation: pickup?.text,
+          dropoffLocation: dropoff?.text,
+          cargoType: description,
+          dimensions: `${length}x${width}x${height}`,
+          weight: 0,
+          timeWindow: '',
+          insurance: false,
+          price,
+        }),
       });
-      navigation.navigate('Orders', { token });
+      navigation.goBack();
     } catch (err) {
       console.log(err);
     }
   }
 
+  async function confirmCreate() {
+    Alert.alert('Підтвердження', 'Ви впевнені що хочете розмістити вантаж?', [
+      { text: 'Скасувати' },
+      { text: 'OK', onPress: create },
+    ]);
+  }
+
+  async function loadSuggestions(text, setter) {
+    if (text.length < 3) {
+      setter([]);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
+          text
+        )}&format=json&limit=5`
+      );
+      const data = await res.json();
+      setter(data);
+    } catch {}
+  }
+
+  useEffect(() => {
+    if (pickup && dropoff) {
+      async function calc() {
+        try {
+          const res = await fetch(
+            `https://router.project-osrm.org/route/v1/driving/${pickup.lon},${pickup.lat};${dropoff.lon},${dropoff.lat}?overview=false`
+          );
+          const data = await res.json();
+          if (data.routes && data.routes[0]) {
+            const km = data.routes[0].distance / 1000;
+            let cost = km * 50;
+            const factor = Math.random() < 0.5 ? 0.95 : 1.15;
+            cost = cost * factor;
+            setPrice(cost.toFixed(0));
+          }
+        } catch {}
+      }
+      calc();
+    }
+  }, [pickup, dropoff]);
+
+  async function pickImage() {
+    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 });
+    if (!res.canceled) {
+      setPhoto(res.assets[0].uri);
+    }
+  }
+
+  function renderSuggestion({ item }, setter, querySetter) {
+    return (
+      <TouchableOpacity
+        style={styles.suggestion}
+        onPress={() => {
+          setter({ text: item.display_name, lat: item.lat, lon: item.lon });
+          querySetter(item.display_name);
+          setPickupSuggestions([]);
+          setDropoffSuggestions([]);
+        }}
+      >
+        <Text>{item.display_name}</Text>
+      </TouchableOpacity>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text>Pickup location</Text>
-      <TextInput style={styles.input} value={pickupLocation} onChangeText={setPickup} />
-      <Text>Dropoff location</Text>
-      <TextInput style={styles.input} value={dropoffLocation} onChangeText={setDropoff} />
-      <Text>Price</Text>
+      <Text>Звідки</Text>
+      <TextInput
+        style={styles.input}
+        value={pickupQuery}
+        onChangeText={(t) => {
+          setPickupQuery(t);
+          setPickup(null);
+          loadSuggestions(t, setPickupSuggestions);
+        }}
+      />
+      <FlatList
+        data={pickupSuggestions}
+        renderItem={(it) => renderSuggestion(it, setPickup, setPickupQuery)}
+        keyExtractor={(item) => item.place_id.toString()}
+      />
+
+      <Text>Куди</Text>
+      <TextInput
+        style={styles.input}
+        value={dropoffQuery}
+        onChangeText={(t) => {
+          setDropoffQuery(t);
+          setDropoff(null);
+          loadSuggestions(t, setDropoffSuggestions);
+        }}
+      />
+      <FlatList
+        data={dropoffSuggestions}
+        renderItem={(it) => renderSuggestion(it, setDropoff, setDropoffQuery)}
+        keyExtractor={(item) => item.place_id.toString()}
+      />
+
+      <Text>Габарити (Д x Ш x В, м)</Text>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TextInput style={[styles.input, styles.dim]} value={length} onChangeText={setLength} keyboardType="numeric" placeholder="Д" />
+        <TextInput style={[styles.input, styles.dim]} value={width} onChangeText={setWidth} keyboardType="numeric" placeholder="Ш" />
+        <TextInput style={[styles.input, styles.dim]} value={height} onChangeText={setHeight} keyboardType="numeric" placeholder="В" />
+      </View>
+
+      <Text>Опис вантажу</Text>
+      <TextInput style={styles.input} value={description} onChangeText={setDescription} />
+
+      <Button title="Додати фото" onPress={pickImage} />
+      {photo && <Image source={{ uri: photo }} style={{ width: 100, height: 100 }} />}
+
+      <Text>Ціна (розраховується автоматично)</Text>
       <TextInput style={styles.input} value={price} onChangeText={setPrice} keyboardType="numeric" />
-      <Button title="Create" onPress={create} />
+
+      <Button title="Створити" onPress={confirmCreate} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
-  input: { borderWidth: 1, padding: 8, marginVertical: 4 }
+  input: { borderWidth: 1, padding: 8, marginVertical: 4, flex: 1 },
+  dim: { flex: 1 },
+  suggestion: {
+    padding: 8,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
 });

--- a/mobile-app/src/screens/MainTabs.js
+++ b/mobile-app/src/screens/MainTabs.js
@@ -2,27 +2,42 @@ import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
 import AllOrdersScreen from './AllOrdersScreen';
-import ActiveOrdersScreen from './ActiveOrdersScreen';
+import CreateOrderScreen from './CreateOrderScreen';
 import SettingsScreen from './SettingsScreen';
 import { colors } from '../components/Colors';
+import MyOrdersScreen from './MyOrdersScreen';
+import { useAuth } from '../AuthContext';
 
 const Tab = createBottomTabNavigator();
 
 export default function MainTabs() {
+  const { role } = useAuth();
+
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         tabBarIcon: ({ color, size }) => {
           let name = 'list';
-          if (route.name === 'Active') name = 'checkmark';
+          if (route.name === 'Create') name = 'add-circle';
+          if (route.name === 'All') name = 'list';
+          if (route.name === 'MyOrders') name = 'briefcase';
           if (route.name === 'Settings') name = 'settings';
           return <Ionicons name={name} size={size} color={color} />;
         },
         tabBarActiveTintColor: colors.green,
       })}
     >
-      <Tab.Screen name="All" component={AllOrdersScreen} options={{ title: 'Всі' }} />
-      <Tab.Screen name="Active" component={ActiveOrdersScreen} options={{ title: 'Активні' }} />
+      {role === 'CUSTOMER' ? (
+        <>
+          <Tab.Screen name="Create" component={CreateOrderScreen} options={{ title: 'Створити' }} />
+          <Tab.Screen name="MyOrders" component={MyOrdersScreen} options={{ title: 'Мої вантажі' }} />
+        </>
+      ) : (
+        <>
+          <Tab.Screen name="All" component={AllOrdersScreen} options={{ title: 'Всі' }} />
+          <Tab.Screen name="MyOrders" component={MyOrdersScreen} options={{ title: 'Мої вантажі' }} />
+        </>
+      )}
       <Tab.Screen name="Settings" component={SettingsScreen} options={{ title: 'Налаштування' }} />
     </Tab.Navigator>
   );

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import { apiFetch } from '../api';
+import { useAuth } from '../AuthContext';
 
 export default function OrderDetailScreen({ route, navigation }) {
   const { order, token } = route.params;
+  const { role } = useAuth();
 
   async function accept() {
     try {
@@ -28,14 +30,36 @@ export default function OrderDetailScreen({ route, navigation }) {
     }
   }
 
+  async function remove() {
+    try {
+      await apiFetch(`/orders/${order.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      navigation.goBack();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  function confirmDelete() {
+    Alert.alert('Підтвердження', 'Видалити вантаж?', [
+      { text: 'Скасувати' },
+      { text: 'OK', onPress: remove },
+    ]);
+  }
+
   return (
     <View style={styles.container}>
       <Text>Pickup: {order.pickupLocation}</Text>
       <Text>Dropoff: {order.dropoffLocation}</Text>
       <Text>Price: {order.price}</Text>
-      <Button title="Accept" onPress={accept} />
-      {order.driverId && (
-        <Button title="Add Favorite" onPress={addFavorite} />
+      {role === 'DRIVER' && !order.driverId && (
+        <Button title="Accept" onPress={accept} />
+      )}
+      {order.driverId && <Button title="Add Favorite" onPress={addFavorite} />}
+      {role === 'CUSTOMER' && !order.driverId && (
+        <Button title="Delete" color="red" onPress={confirmDelete} />
       )}
     </View>
   );

--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -1,13 +1,28 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text, Switch } from 'react-native';
 import AppButton from '../components/AppButton';
 import { useAuth } from '../AuthContext';
 
 export default function SettingsScreen() {
-  const { logout } = useAuth();
+  const { logout, role, selectRole } = useAuth();
+  const isCustomer = role === 'CUSTOMER';
+
+  function toggleRole() {
+    selectRole(isCustomer ? 'DRIVER' : 'CUSTOMER');
+  }
 
   return (
     <View style={styles.container}>
+      <View style={styles.switchRow}>
+        <Text style={styles.label}>Замовник</Text>
+        <Switch
+          value={!isCustomer}
+          onValueChange={toggleRole}
+          trackColor={{ false: '#ccc', true: '#6abf69' }}
+          thumbColor="#fff"
+        />
+        <Text style={styles.label}>Водій</Text>
+      </View>
       <AppButton title="Вийти" onPress={logout} />
     </View>
   );
@@ -15,4 +30,12 @@ export default function SettingsScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 24 },
+  switchRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+    gap: 8,
+  },
+  label: { fontSize: 16 },
 });

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -105,4 +105,21 @@ async function updateStatus(req, res) {
   }
 }
 
-module.exports = { createOrder, listAvailableOrders, acceptOrder, updateStatus, listMyOrders };
+async function deleteOrder(req, res) {
+  const id = req.params.id;
+  try {
+    const order = await Order.findByPk(id);
+    if (!order) {
+      return res.status(404).send('Замовлення не знайдено');
+    }
+    if (order.customerId !== req.user.id || order.status !== 'CREATED') {
+      return res.status(400).send('Неможливо видалити');
+    }
+    await order.destroy();
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(400).send('Помилка видалення');
+  }
+}
+
+module.exports = { createOrder, listAvailableOrders, acceptOrder, updateStatus, listMyOrders, deleteOrder };

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -1,6 +1,13 @@
 const { Router } = require('express');
 const { authenticate, authorize } = require('../middlewares/auth');
-const { createOrder, listAvailableOrders, acceptOrder, updateStatus, listMyOrders } = require('../controllers/orderController');
+const {
+  createOrder,
+  listAvailableOrders,
+  acceptOrder,
+  updateStatus,
+  listMyOrders,
+  deleteOrder,
+} = require('../controllers/orderController');
 const { UserRole } = require('../models/user');
 
 const router = Router();
@@ -10,5 +17,6 @@ router.get('/', authenticate, authorize([UserRole.DRIVER]), listAvailableOrders)
 router.get('/my', authenticate, listMyOrders);
 router.post('/:id/accept', authenticate, authorize([UserRole.DRIVER]), acceptOrder);
 router.patch('/:id/status', authenticate, updateStatus);
+router.delete('/:id', authenticate, authorize([UserRole.CUSTOMER]), deleteOrder);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow switching between customer and driver roles in settings
- adapt tabs per role
- expand order creation with address search, dimensions, photo and price calculation
- let customers delete unassigned orders
- expose order delete endpoint in backend
- add expo-image-picker dependency

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6853f94443c483249ea170b264a1151b