### PR TITLE
Improve role switching UX

### DIFF
--- a/mobile-app/src/AuthContext.js
+++ b/mobile-app/src/AuthContext.js
@@ -19,8 +19,13 @@ export function AuthProvider({ children }) {
               headers: { Authorization: `Bearer ${storedToken}` },
             });
             setToken(storedToken);
-            setRole(me.role);
-            await AsyncStorage.setItem('role', me.role);
+            const r = me.role === 'BOTH' ? null : me.role;
+            setRole(r);
+            if (r) {
+              await AsyncStorage.setItem('role', r);
+            } else {
+              await AsyncStorage.removeItem('role');
+            }
           } catch {
             await AsyncStorage.removeItem('token');
             await AsyncStorage.removeItem('role');
@@ -37,15 +42,25 @@ export function AuthProvider({ children }) {
     await AsyncStorage.setItem('token', tok);
     setToken(tok);
     if (r) {
-      await AsyncStorage.setItem('role', r);
-      setRole(r);
+      const roleVal = r === 'BOTH' ? null : r;
+      if (roleVal) {
+        await AsyncStorage.setItem('role', roleVal);
+      } else {
+        await AsyncStorage.removeItem('role');
+      }
+      setRole(roleVal);
     } else {
       try {
         const me = await apiFetch('/auth/me', {
           headers: { Authorization: `Bearer ${tok}` },
         });
-        await AsyncStorage.setItem('role', me.role);
-        setRole(me.role);
+        const roleVal = me.role === 'BOTH' ? null : me.role;
+        if (roleVal) {
+          await AsyncStorage.setItem('role', roleVal);
+        } else {
+          await AsyncStorage.removeItem('role');
+        }
+        setRole(roleVal);
       } catch {
         await AsyncStorage.removeItem('token');
         await AsyncStorage.removeItem('role');

--- a/mobile-app/src/components/RoleSwitch.js
+++ b/mobile-app/src/components/RoleSwitch.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { colors } from './Colors';
+
+export default function RoleSwitch({ value, onChange, style }) {
+  return (
+    <View style={[styles.container, style]}>
+      <Pressable
+        style={[styles.option, value === 'CUSTOMER' && styles.activeLeft]}
+        onPress={() => onChange('CUSTOMER')}
+      >
+        <Text style={[styles.text, value === 'CUSTOMER' && styles.activeText]}>Замовник</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.option, value === 'DRIVER' && styles.activeRight]}
+        onPress={() => onChange('DRIVER')}
+      >
+        <Text style={[styles.text, value === 'DRIVER' && styles.activeText]}>Водій</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  option: {
+    flex: 1,
+    paddingVertical: 8,
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  activeLeft: {
+    backgroundColor: colors.green,
+    borderTopLeftRadius: 20,
+    borderBottomLeftRadius: 20,
+  },
+  activeRight: {
+    backgroundColor: colors.green,
+    borderTopRightRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  activeText: {
+    color: '#fff',
+  },
+  text: {
+    color: colors.text,
+  },
+});

--- a/mobile-app/src/screens/RoleScreen.js
+++ b/mobile-app/src/screens/RoleScreen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import AppButton from '../components/AppButton';
 import { useAuth } from '../AuthContext';
+import RoleSwitch from '../components/RoleSwitch';
 
 export default function RoleScreen() {
   const { selectRole } = useAuth();
@@ -12,12 +12,12 @@ export default function RoleScreen() {
 
   return (
     <View style={styles.container}>
-      <AppButton title="Я водій" onPress={() => choose('DRIVER')} />
-      <AppButton title="Я замовник" onPress={() => choose('CUSTOMER')} />
+      <RoleSwitch value={null} onChange={choose} style={styles.switch} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  switch: { width: '80%' },
 });

--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -1,28 +1,19 @@
 import React from 'react';
-import { View, StyleSheet, Text, Switch } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import AppButton from '../components/AppButton';
 import { useAuth } from '../AuthContext';
+import RoleSwitch from '../components/RoleSwitch';
 
 export default function SettingsScreen() {
   const { logout, role, selectRole } = useAuth();
-  const isCustomer = role === 'CUSTOMER';
 
-  function toggleRole() {
-    selectRole(isCustomer ? 'DRIVER' : 'CUSTOMER');
+  function handleChange(r) {
+    if (r !== role) selectRole(r);
   }
 
   return (
     <View style={styles.container}>
-      <View style={styles.switchRow}>
-        <Text style={styles.label}>Замовник</Text>
-        <Switch
-          value={!isCustomer}
-          onValueChange={toggleRole}
-          trackColor={{ false: '#ccc', true: '#6abf69' }}
-          thumbColor="#fff"
-        />
-        <Text style={styles.label}>Водій</Text>
-      </View>
+      <RoleSwitch value={role} onChange={handleChange} style={styles.switch} />
       <AppButton title="Вийти" onPress={logout} />
     </View>
   );
@@ -30,12 +21,6 @@ export default function SettingsScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 24 },
-  switchRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: 24,
-    gap: 8,
-  },
-  label: { fontSize: 16 },
+  switch: { marginBottom: 24 },
+
 });


### PR DESCRIPTION
## Summary
- handle BOTH role to trigger role selection
- add custom `RoleSwitch` component
- update settings screen with new role switch
- refresh role selection screen to use `RoleSwitch`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854000e0b908324b70ca91cc95f9d8b