### PR TITLE
Improve CreateOrder screen

### DIFF
--- a/mobile-app/src/components/DateTimeInput.js
+++ b/mobile-app/src/components/DateTimeInput.js
@@ -4,23 +4,44 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import AppInput from './AppInput';
 
 export default function DateTimeInput({ value, onChange }) {
-  const [show, setShow] = useState(false);
-  function onChangeInner(_e, selected) {
-    setShow(false);
-    if (selected) onChange(selected);
+  const [showDate, setShowDate] = useState(false);
+  const [showTime, setShowTime] = useState(false);
+
+  function onChangeDate(_e, selected) {
+    setShowDate(false);
+    if (!selected) return;
+    const newDate = new Date(value);
+    newDate.setFullYear(selected.getFullYear(), selected.getMonth(), selected.getDate());
+    onChange(newDate);
   }
+
+  function onChangeTime(_e, selected) {
+    setShowTime(false);
+    if (!selected) return;
+    const newDate = new Date(value);
+    newDate.setHours(selected.getHours());
+    newDate.setMinutes(selected.getMinutes());
+    onChange(newDate);
+  }
+
   return (
-    <View>
-      <TouchableOpacity onPress={() => setShow(true)}>
-        <AppInput
-          value={formatDate(value)}
-          editable={false}
-          pointerEvents="none"
-        />
-      </TouchableOpacity>
-      {show && (
-        <DateTimePicker value={value} mode="datetime" is24Hour onChange={onChangeInner} />
-      )}
+    <View style={styles.row}>
+      <View style={{ flex: 1 }}>
+        <TouchableOpacity onPress={() => setShowDate(true)}>
+          <AppInput value={formatDate(value)} editable={false} pointerEvents="none" />
+        </TouchableOpacity>
+        {showDate && (
+          <DateTimePicker value={value} mode="date" is24Hour onChange={onChangeDate} />
+        )}
+      </View>
+      <View style={{ flex: 1 }}>
+        <TouchableOpacity onPress={() => setShowTime(true)}>
+          <AppInput value={formatTime(value)} editable={false} pointerEvents="none" />
+        </TouchableOpacity>
+        {showTime && (
+          <DateTimePicker value={value} mode="time" is24Hour onChange={onChangeTime} />
+        )}
+      </View>
     </View>
   );
 }
@@ -28,7 +49,15 @@ export default function DateTimeInput({ value, onChange }) {
 function formatDate(d) {
   if (!d) return '';
   const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
-const styles = StyleSheet.create({});
+function formatTime(d) {
+  if (!d) return '';
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', gap: 8 },
+});

--- a/mobile-app/src/components/PhotoPicker.js
+++ b/mobile-app/src/components/PhotoPicker.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity, Image, Modal, StyleSheet } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { Ionicons } from '@expo/vector-icons';
+import AppButton from './AppButton';
+
+export default function PhotoPicker({ photo, onChange }) {
+  const [preview, setPreview] = useState(false);
+
+  async function pickFromLibrary() {
+    const res = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.5,
+    });
+    if (!res.canceled) onChange(res.assets[0].uri);
+  }
+
+  async function takePhoto() {
+    const res = await ImagePicker.launchCameraAsync({
+      quality: 0.5,
+    });
+    if (!res.canceled) onChange(res.assets[0].uri);
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <AppButton title="Фото" onPress={takePhoto} style={{ flex: 1 }} />
+        <AppButton title="Галерея" onPress={pickFromLibrary} style={{ flex: 1 }} />
+      </View>
+      {photo && (
+        <TouchableOpacity onPress={() => setPreview(true)}>
+          <Image source={{ uri: photo }} style={styles.thumbnail} />
+        </TouchableOpacity>
+      )}
+      {photo && (
+        <Modal visible={preview} transparent>
+          <View style={styles.modal}>
+            <TouchableOpacity style={styles.close} onPress={() => setPreview(false)}>
+              <Ionicons name="close" size={32} color="#fff" />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.delete}
+              onPress={() => {
+                onChange(null);
+                setPreview(false);
+              }}
+            >
+              <Ionicons name="trash" size={32} color="#fff" />
+            </TouchableOpacity>
+            <Image source={{ uri: photo }} style={styles.full} resizeMode="contain" />
+          </View>
+        </Modal>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center' },
+  thumbnail: { width: 100, height: 100, marginVertical: 8 },
+  modal: { flex: 1, backgroundColor: 'black', justifyContent: 'center', alignItems: 'center' },
+  full: { width: '100%', height: '100%' },
+  close: { position: 'absolute', top: 40, right: 20, zIndex: 1 },
+  delete: { position: 'absolute', top: 40, left: 20, zIndex: 1 },
+});

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import {
   View,
   StyleSheet,
-  FlatList,
   TouchableOpacity,
-  Image,
   Alert,
   ScrollView,
 } from 'react-native';
@@ -13,7 +11,7 @@ import AppInput from '../components/AppInput';
 import AppButton from '../components/AppButton';
 import DateTimeInput from '../components/DateTimeInput';
 import { colors } from '../components/Colors';
-import * as ImagePicker from 'expo-image-picker';
+import PhotoPicker from '../components/PhotoPicker';
 import { apiFetch } from '../api';
 import { useAuth } from '../AuthContext';
 
@@ -106,28 +104,7 @@ export default function CreateOrderScreen({ navigation }) {
   }
 
 
-  async function pickImage() {
-    const res = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 });
-    if (!res.canceled) {
-      setPhoto(res.assets[0].uri);
-    }
-  }
 
-  function renderSuggestion({ item }, setter, querySetter) {
-    return (
-      <TouchableOpacity
-        style={styles.suggestion}
-        onPress={() => {
-          setter({ text: item.display_name, lat: item.lat, lon: item.lon });
-          querySetter(item.display_name);
-          setPickupSuggestions([]);
-          setDropoffSuggestions([]);
-        }}
-      >
-        <AppText>{item.display_name}</AppText>
-      </TouchableOpacity>
-    );
-  }
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
@@ -140,11 +117,20 @@ export default function CreateOrderScreen({ navigation }) {
           loadSuggestions(t, setPickupSuggestions);
         }}
       />
-      <FlatList
-        data={pickupSuggestions}
-        renderItem={(it) => renderSuggestion(it, setPickup, setPickupQuery)}
-        keyExtractor={(item) => item.place_id.toString()}
-      />
+      {pickupSuggestions.map((item) => (
+        <TouchableOpacity
+          key={item.place_id}
+          style={styles.suggestion}
+          onPress={() => {
+            setPickup({ text: item.display_name, lat: item.lat, lon: item.lon });
+            setPickupQuery(item.display_name);
+            setPickupSuggestions([]);
+            setDropoffSuggestions([]);
+          }}
+        >
+          <AppText>{item.display_name}</AppText>
+        </TouchableOpacity>
+      ))}
 
       <AppText style={styles.label}>Куди</AppText>
       <AppInput
@@ -155,11 +141,20 @@ export default function CreateOrderScreen({ navigation }) {
           loadSuggestions(t, setDropoffSuggestions);
         }}
       />
-      <FlatList
-        data={dropoffSuggestions}
-        renderItem={(it) => renderSuggestion(it, setDropoff, setDropoffQuery)}
-        keyExtractor={(item) => item.place_id.toString()}
-      />
+      {dropoffSuggestions.map((item) => (
+        <TouchableOpacity
+          key={item.place_id}
+          style={styles.suggestion}
+          onPress={() => {
+            setDropoff({ text: item.display_name, lat: item.lat, lon: item.lon });
+            setDropoffQuery(item.display_name);
+            setPickupSuggestions([]);
+            setDropoffSuggestions([]);
+          }}
+        >
+          <AppText>{item.display_name}</AppText>
+        </TouchableOpacity>
+      ))}
 
       <AppText style={styles.label}>Дата завантаження</AppText>
       <DateTimeInput value={loadDate} onChange={setLoadDate} />
@@ -174,14 +169,15 @@ export default function CreateOrderScreen({ navigation }) {
       </View>
 
       <AppText style={styles.label}>Опис вантажу</AppText>
-      <AppInput value={description} onChangeText={setDescription} />
+      <AppInput
+        value={description}
+        onChangeText={setDescription}
+        multiline
+        numberOfLines={4}
+        style={{ height: 100, textAlignVertical: 'top' }}
+      />
 
-      <AppButton title="Додати фото" onPress={pickImage} />
-      {photo && (
-        <TouchableOpacity onPress={() => setPhoto(null)}>
-          <Image source={{ uri: photo }} style={{ width: 100, height: 100 }} />
-        </TouchableOpacity>
-      )}
+      <PhotoPicker photo={photo} onChange={setPhoto} />
 
       <AppButton title="Створити" onPress={confirmCreate} />
     </ScrollView>


### PR DESCRIPTION
## Summary
- separate date and time inputs
- add reusable PhotoPicker with camera support and full-screen preview
- update CreateOrderScreen to use new components and allow multiline description
- replace nested FlatLists to avoid virtualization warning

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix mobile-app test` *(fails: Missing script)*
- `npm install`
- `npm --prefix mobile-app install`


------
https://chatgpt.com/codex/tasks/task_e_68540a78043883249a960b174741110b