### PR TITLE
Adjust order date inputs

### DIFF
--- a/mobile-app/src/components/DateInput.js
+++ b/mobile-app/src/components/DateInput.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import AppInput from './AppInput';
+
+export default function DateInput({ value, onChange }) {
+  const [showDate, setShowDate] = useState(false);
+
+  function onChangeDate(_e, selected) {
+    setShowDate(false);
+    if (!selected) return;
+    const newDate = new Date(value);
+    newDate.setFullYear(selected.getFullYear(), selected.getMonth(), selected.getDate());
+    onChange(newDate);
+  }
+
+  return (
+    <View>
+      <TouchableOpacity onPress={() => setShowDate(true)}>
+        <AppInput value={formatDate(value)} editable={false} pointerEvents="none" />
+      </TouchableOpacity>
+      {showDate && (
+        <DateTimePicker value={value} mode="date" is24Hour onChange={onChangeDate} />
+      )}
+    </View>
+  );
+}
+
+function formatDate(d) {
+  if (!d) return '';
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}

--- a/mobile-app/src/components/TimeInput.js
+++ b/mobile-app/src/components/TimeInput.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import AppInput from './AppInput';
+
+export default function TimeInput({ value, onChange }) {
+  const [showTime, setShowTime] = useState(false);
+
+  function onChangeTime(_e, selected) {
+    setShowTime(false);
+    if (!selected) return;
+    const newDate = new Date(value);
+    newDate.setHours(selected.getHours());
+    newDate.setMinutes(selected.getMinutes());
+    onChange(newDate);
+  }
+
+  return (
+    <View>
+      <TouchableOpacity onPress={() => setShowTime(true)}>
+        <AppInput value={formatTime(value)} editable={false} pointerEvents="none" />
+      </TouchableOpacity>
+      {showTime && (
+        <DateTimePicker value={value} mode="time" is24Hour onChange={onChangeTime} />
+      )}
+    </View>
+  );
+}
+
+function formatTime(d) {
+  if (!d) return '';
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -11,6 +11,8 @@ import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
 import AppButton from '../components/AppButton';
 import DateTimeInput from '../components/DateTimeInput';
+import DateInput from '../components/DateInput';
+import TimeInput from '../components/TimeInput';
 import { colors } from '../components/Colors';
 import PhotoPicker from '../components/PhotoPicker';
 import { apiFetch } from '../api';
@@ -205,14 +207,39 @@ export default function CreateOrderScreen({ navigation }) {
         </Modal>
       )}
 
-      <AppText style={styles.label}>Завантаження з</AppText>
-      <DateTimeInput value={loadFrom} onChange={setLoadFrom} />
-      <AppText style={styles.label}>Завантаження до</AppText>
-      <DateTimeInput value={loadTo} onChange={setLoadTo} />
-      <AppText style={styles.label}>Вивантаження з</AppText>
-      <DateTimeInput value={unloadFrom} onChange={setUnloadFrom} />
-      <AppText style={styles.label}>Вивантаження до</AppText>
-      <DateTimeInput value={unloadTo} onChange={setUnloadTo} />
+      <AppText style={styles.label}>Завантаження</AppText>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput value={loadFrom} onChange={setLoadFrom} />
+        <DateInput
+          value={loadFrom}
+          onChange={(d) => {
+            const from = new Date(loadFrom);
+            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+            const to = new Date(loadTo);
+            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+            setLoadFrom(from);
+            setLoadTo(to);
+          }}
+        />
+        <TimeInput value={loadTo} onChange={setLoadTo} />
+      </View>
+
+      <AppText style={styles.label}>Вивантаження</AppText>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput value={unloadFrom} onChange={setUnloadFrom} />
+        <DateInput
+          value={unloadFrom}
+          onChange={(d) => {
+            const from = new Date(unloadFrom);
+            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+            const to = new Date(unloadTo);
+            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+            setUnloadFrom(from);
+            setUnloadTo(to);
+          }}
+        />
+        <TimeInput value={unloadTo} onChange={setUnloadTo} />
+      </View>
 
       <AppText style={styles.label}>Габарити (Д x Ш x В, м)</AppText>
       <View style={{ flexDirection: 'row', gap: 8 }}>


### PR DESCRIPTION
## Summary
- add `DateInput` and `TimeInput` components for separate pickers
- update `CreateOrderScreen` to use new components
- combine load/unload times under a single date field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854753b97708324b2a370a9865f1b51