### PR TITLE
Fix create order screen and allow multiple photos

### DIFF
--- a/mobile-app/src/components/PhotoPicker.js
+++ b/mobile-app/src/components/PhotoPicker.js
@@ -1,25 +1,25 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity, Image, Modal, StyleSheet } from 'react-native';
+import { View, TouchableOpacity, Image, Modal, StyleSheet, ScrollView } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import AppButton from './AppButton';
 
-export default function PhotoPicker({ photo, onChange }) {
-  const [preview, setPreview] = useState(false);
+export default function PhotoPicker({ photos, onChange }) {
+  const [previewIndex, setPreviewIndex] = useState(null);
 
   async function pickFromLibrary() {
     const res = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       quality: 0.5,
     });
-    if (!res.canceled) onChange(res.assets[0].uri);
+    if (!res.canceled) onChange([...(photos || []), res.assets[0].uri]);
   }
 
   async function takePhoto() {
     const res = await ImagePicker.launchCameraAsync({
       quality: 0.5,
     });
-    if (!res.canceled) onChange(res.assets[0].uri);
+    if (!res.canceled) onChange([...(photos || []), res.assets[0].uri]);
   }
 
   return (
@@ -28,27 +28,32 @@ export default function PhotoPicker({ photo, onChange }) {
         <AppButton title="Фото" onPress={takePhoto} style={{ flex: 1 }} />
         <AppButton title="Галерея" onPress={pickFromLibrary} style={{ flex: 1 }} />
       </View>
-      {photo && (
-        <TouchableOpacity onPress={() => setPreview(true)}>
-          <Image source={{ uri: photo }} style={styles.thumbnail} />
-        </TouchableOpacity>
+      {photos && photos.length > 0 && (
+        <ScrollView horizontal style={{ marginTop: 8 }}>
+          {photos.map((p, i) => (
+            <TouchableOpacity key={i} onPress={() => setPreviewIndex(i)}>
+              <Image source={{ uri: p }} style={styles.thumbnail} />
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
       )}
-      {photo && (
-        <Modal visible={preview} transparent>
+      {previewIndex !== null && photos && (
+        <Modal visible transparent>
           <View style={styles.modal}>
-            <TouchableOpacity style={styles.close} onPress={() => setPreview(false)}>
+            <TouchableOpacity style={styles.close} onPress={() => setPreviewIndex(null)}>
               <Ionicons name="close" size={32} color="#fff" />
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.delete}
               onPress={() => {
-                onChange(null);
-                setPreview(false);
+                const newPhotos = photos.filter((_, idx) => idx !== previewIndex);
+                onChange(newPhotos);
+                setPreviewIndex(null);
               }}
             >
               <Ionicons name="trash" size={32} color="#fff" />
             </TouchableOpacity>
-            <Image source={{ uri: photo }} style={styles.full} resizeMode="contain" />
+            <Image source={{ uri: photos[previewIndex] }} style={styles.full} resizeMode="contain" />
           </View>
         </Modal>
       )}
@@ -58,7 +63,7 @@ export default function PhotoPicker({ photo, onChange }) {
 
 const styles = StyleSheet.create({
   container: { alignItems: 'center' },
-  thumbnail: { width: 100, height: 100, marginVertical: 8 },
+  thumbnail: { width: 100, height: 100, marginRight: 8 },
   modal: { flex: 1, backgroundColor: 'black', justifyContent: 'center', alignItems: 'center' },
   full: { width: '100%', height: '100%' },
   close: { position: 'absolute', top: 40, right: 20, zIndex: 1 },

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -37,7 +37,7 @@ export default function CreateOrderScreen({ navigation }) {
   const [loadTo, setLoadTo] = useState(new Date(now.getTime() + 60 * 60 * 1000));
   const [unloadFrom, setUnloadFrom] = useState(new Date(now.getTime() + 24 * 60 * 60 * 1000));
   const [unloadTo, setUnloadTo] = useState(new Date(now.getTime() + 25 * 60 * 60 * 1000));
-  const [photo, setPhoto] = useState(null);
+  const [photos, setPhotos] = useState([]);
   const [description, setDescription] = useState('');
 
   async function create() {
@@ -61,18 +61,31 @@ export default function CreateOrderScreen({ navigation }) {
       fd.append('unloadFrom', unloadFrom.toISOString());
       fd.append('unloadTo', unloadTo.toISOString());
       fd.append('insurance', 'false');
-      if (photo) {
-        const filename = photo.split('/').pop();
-        const match = /\.([a-zA-Z0-9]+)$/.exec(filename || '');
-        const type = match ? `image/${match[1]}` : `image`;
-        fd.append('photo', { uri: photo, name: filename, type });
+      if (photos && photos.length > 0) {
+        photos.forEach((p) => {
+          const filename = p.split('/').pop();
+          const match = /\.([a-zA-Z0-9]+)$/.exec(filename || '');
+          const type = match ? `image/${match[1]}` : 'image';
+          fd.append('photos', { uri: p, name: filename, type });
+        });
       }
       await apiFetch('/orders', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: fd,
       });
-      navigation.goBack();
+      setPickupQuery('');
+      setPickup(null);
+      setPickupSuggestions([]);
+      setDropoffQuery('');
+      setDropoff(null);
+      setDropoffSuggestions([]);
+      setLength('');
+      setWidth('');
+      setHeight('');
+      setDescription('');
+      setPhotos([]);
+      navigation.navigate('MyOrders');
     } catch (err) {
       console.log(err);
     }
@@ -266,7 +279,7 @@ export default function CreateOrderScreen({ navigation }) {
         style={{ height: 100, textAlignVertical: 'top' }}
       />
 
-      <PhotoPicker photo={photo} onChange={setPhoto} />
+      <PhotoPicker photos={photos} onChange={setPhotos} />
 
       <AppButton title="Створити" onPress={confirmCreate} />
     </ScrollView>

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -46,7 +46,7 @@ async function createOrder(req, res) {
       insurance,
       price,
       city,
-      photo: req.file ? `/uploads/${req.file.filename}` : null,
+      photos: req.files ? req.files.map((f) => `/uploads/${f.filename}`) : [],
     });
     res.json(order);
   } catch (err) {

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -29,7 +29,7 @@ Order.init(
     insurance: { type: DataTypes.BOOLEAN, defaultValue: false },
     status: { type: DataTypes.ENUM(...Object.values(OrderStatus)), defaultValue: OrderStatus.CREATED },
     price: { type: DataTypes.FLOAT, allowNull: false },
-    photo: { type: DataTypes.STRING },
+    photos: { type: DataTypes.JSON },
     city: { type: DataTypes.STRING },
   },
   { sequelize: db, modelName: 'order' }

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -13,7 +13,7 @@ const { UserRole } = require('../models/user');
 
 const router = Router();
 
-router.post('/', authenticate, authorize([UserRole.CUSTOMER]), upload.single('photo'), createOrder);
+router.post('/', authenticate, authorize([UserRole.CUSTOMER]), upload.array('photos', 10), createOrder);
 router.get('/', authenticate, authorize([UserRole.DRIVER]), listAvailableOrders);
 router.get('/my', authenticate, listMyOrders);
 router.post('/:id/accept', authenticate, authorize([UserRole.DRIVER]), acceptOrder);

--- a/src/seed.js
+++ b/src/seed.js
@@ -23,7 +23,7 @@ async function seed() {
     unloadTo: new Date(Date.now() + 90000000),
     insurance: false,
     price: 100,
-    photo: null,
+    photos: [],
     city: 'NYC',
   });
 


### PR DESCRIPTION
## Summary
- handle arrays of photos on backend and seed
- support multiple photo selection on mobile and update API call
- reset order form on success and redirect to My Orders
- avoid deprecated MediaTypeOptions constant

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test` in mobile-app *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68547dfd3d7c832485214965b2c64a0d