### PR TITLE
Add price slider for cargo creation

### DIFF
--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "^7.5.0",
+        "@react-native-community/slider": "^5.0.0",
         "@react-navigation/bottom-tabs": "^7.3.17",
         "@react-navigation/native": "^7.1.11",
         "@react-navigation/native-stack": "^7.3.16",
@@ -2162,6 +2164,21 @@
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.7.0.tgz",
+      "integrity": "sha512-nYzZy4DQLRFUzKJShWzRleCaebmCJfZ1lIcFmZgMXJoiVuGJNw3OIGHSWmHhPETh3OhP1RO3to882d7WmDIyrA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.0.tgz",
+      "integrity": "sha512-D7raJNcG6CID5JQO0V+VhHkLtWLdvPSosPGtE+azSgoPDJmp16gFhW4gBltP0GVECri3Xm+a+pfz49kDuBAlcQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.3",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -18,7 +18,8 @@
     "react": "19.0.0",
     "react-native": "0.79.3",
     "expo-image-picker": "^16.1.4",
-    "@react-native-community/datetimepicker": "^7.5.0"
+    "@react-native-community/datetimepicker": "^7.5.0",
+    "@react-native-community/slider": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -29,6 +29,9 @@ export default function MyOrdersScreen({ navigation }) {
           <Text style={styles.route}>
             {item.pickupLocation} ➔ {item.dropoffLocation}
           </Text>
+          <Text style={styles.status}>
+            {new Date(item.loadFrom).toLocaleString()} • {Math.round(item.price)} грн
+          </Text>
           <Text style={styles.status}>{item.status}</Text>
         </View>
       </TouchableOpacity>

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -20,6 +20,7 @@ async function createOrder(req, res) {
     insurance,
     city,
   } = req.body;
+  let systemPrice = 0;
   let price = 0;
   try {
     if (pickupLat && pickupLon && dropoffLat && dropoffLon) {
@@ -29,7 +30,8 @@ async function createOrder(req, res) {
       const data = await resRoute.json();
       if (data.routes && data.routes[0]) {
         const km = data.routes[0].distance / 1000;
-        price = km * 50 * (Math.random() < 0.5 ? 0.95 : 1.15);
+        systemPrice = km * 50;
+        price = parseFloat(req.body.price || systemPrice);
       }
     }
     const order = await Order.create({
@@ -44,6 +46,7 @@ async function createOrder(req, res) {
       unloadFrom,
       unloadTo,
       insurance,
+      systemPrice,
       price,
       city,
       photos: req.files ? req.files.map((f) => `/uploads/${f.filename}`) : [],

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -28,6 +28,7 @@ Order.init(
     unloadTo: { type: DataTypes.DATE, allowNull: false },
     insurance: { type: DataTypes.BOOLEAN, defaultValue: false },
     status: { type: DataTypes.ENUM(...Object.values(OrderStatus)), defaultValue: OrderStatus.CREATED },
+    systemPrice: { type: DataTypes.FLOAT, allowNull: false, defaultValue: 0 },
     price: { type: DataTypes.FLOAT, allowNull: false },
     photos: { type: DataTypes.JSON },
     city: { type: DataTypes.STRING },

--- a/src/seed.js
+++ b/src/seed.js
@@ -22,6 +22,7 @@ async function seed() {
     unloadFrom: new Date(Date.now() + 86400000),
     unloadTo: new Date(Date.now() + 90000000),
     insurance: false,
+    systemPrice: 100,
     price: 100,
     photos: [],
     city: 'NYC',


### PR DESCRIPTION
## Summary
- save base and final price for orders in backend
- compute price suggestion in frontend and allow adjusting via slider
- show price and time in user's order list
- add slider dependency for the mobile app

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix mobile-app test` *(fails: Missing script)*
- `npm --prefix mobile-app install`

------
https://chatgpt.com/codex/tasks/task_e_685481e4ce7883249c6e5c100be0088e