### PR TITLE
Add map selection and order fields

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -7,6 +7,8 @@ import LoginScreen from './src/screens/LoginScreen';
 import RegisterScreen from './src/screens/RegisterScreen';
 import RoleScreen from './src/screens/RoleScreen';
 import MainTabs from './src/screens/MainTabs';
+import MapSelectScreen from './src/screens/MapSelectScreen';
+import OrderDetailScreen from './src/screens/OrderDetailScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -25,7 +27,11 @@ function RootNavigator() {
       ) : role == null ? (
         <Stack.Screen name="Role" component={RoleScreen} />
       ) : (
-        <Stack.Screen name="Main" component={MainTabs} />
+        <>
+          <Stack.Screen name="Main" component={MainTabs} />
+          <Stack.Screen name="MapSelect" component={MapSelectScreen} />
+          <Stack.Screen name="OrderDetail" component={OrderDetailScreen} />
+        </>
       )}
     </Stack.Navigator>
   );

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -18,7 +18,8 @@
         "expo-image-picker": "^16.1.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
-        "react-native": "0.79.3"
+        "react-native": "0.79.3",
+        "react-native-maps": "^1.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -2600,6 +2601,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -6277,6 +6284,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.3.tgz",
+      "integrity": "sha512-cF5oTA8z24QqGIRFfDcsXLEs/gCd0RhaJ9KPv/2HiogKD5gpjh1naimZUJQ6IsEcUngSSk8iov6p2jd7dB+/bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -19,7 +19,8 @@
     "react-native": "0.79.3",
     "expo-image-picker": "^16.1.4",
     "@react-native-community/datetimepicker": "^7.5.0",
-    "@react-native-community/slider": "^5.0.0"
+    "@react-native-community/slider": "^5.0.0",
+    "react-native-maps": "^1.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile-app/src/components/CheckBox.js
+++ b/mobile-app/src/components/CheckBox.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from './Colors';
+
+export default function CheckBox({ value, onChange, size = 24 }) {
+  return (
+    <TouchableOpacity onPress={() => onChange(!value)}>
+      <Ionicons
+        name={value ? 'checkbox' : 'square-outline'}
+        size={size}
+        color={colors.green}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/mobile-app/src/components/OptionSwitch.js
+++ b/mobile-app/src/components/OptionSwitch.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { colors } from './Colors';
+
+export default function OptionSwitch({ options, value, onChange, style }) {
+  return (
+    <View style={[styles.container, style]}>
+      {options.map((opt, idx) => (
+        <Pressable
+          key={opt.value}
+          style={[
+            styles.option,
+            value === opt.value && (idx === 0 ? styles.activeLeft : styles.activeRight),
+          ]}
+          onPress={() => onChange(opt.value)}
+        >
+          <Text style={[styles.text, value === opt.value && styles.activeText]}>{opt.label}</Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  option: {
+    flex: 1,
+    paddingVertical: 8,
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  activeLeft: {
+    backgroundColor: colors.green,
+    borderTopLeftRadius: 20,
+    borderBottomLeftRadius: 20,
+  },
+  activeRight: {
+    backgroundColor: colors.green,
+    borderTopRightRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  text: { color: colors.text },
+  activeText: { color: '#fff' },
+});

--- a/mobile-app/src/screens/MapSelectScreen.js
+++ b/mobile-app/src/screens/MapSelectScreen.js
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { Ionicons } from '@expo/vector-icons';
+import AppButton from '../components/AppButton';
+
+export default function MapSelectScreen({ navigation, route }) {
+  const { onSelect, address, lat, lon } = route.params || {};
+  const [region, setRegion] = useState({
+    latitude: lat ? parseFloat(lat) : 50.4501,
+    longitude: lon ? parseFloat(lon) : 30.5234,
+    latitudeDelta: 0.05,
+    longitudeDelta: 0.05,
+  });
+  const [marker, setMarker] = useState(lat && lon ? { latitude: parseFloat(lat), longitude: parseFloat(lon) } : null);
+
+  useEffect(() => {
+    async function geocode() {
+      if (!marker && address) {
+        try {
+          const res = await fetch(
+            `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(address)}&format=json&limit=1&countrycodes=ua`,
+            { headers: { 'User-Agent': 'vango-app' } }
+          );
+          const data = await res.json();
+          if (data && data[0]) {
+            const la = parseFloat(data[0].lat);
+            const lo = parseFloat(data[0].lon);
+            setRegion({ latitude: la, longitude: lo, latitudeDelta: 0.05, longitudeDelta: 0.05 });
+            setMarker({ latitude: la, longitude: lo });
+          }
+        } catch {}
+      }
+    }
+    geocode();
+  }, []);
+
+  function confirm() {
+    if (onSelect && marker) {
+      onSelect({ lat: marker.latitude, lon: marker.longitude });
+    }
+    navigation.goBack();
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <MapView style={{ flex: 1 }} region={region} onPress={(e) => setMarker(e.nativeEvent.coordinate)}>
+        {marker && <Marker coordinate={marker} />}
+      </MapView>
+      <TouchableOpacity style={styles.back} onPress={() => navigation.goBack()}>
+        <Ionicons name="arrow-back" size={32} color="#333" />
+      </TouchableOpacity>
+      {marker && (
+        <AppButton title="Підтвердити" onPress={confirm} style={styles.confirm} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  back: { position: 'absolute', top: 40, left: 20, backgroundColor: '#fff', borderRadius: 20, padding: 6 },
+  confirm: { position: 'absolute', bottom: 40, left: 20, right: 20 },
+});


### PR DESCRIPTION
## Summary
- add generic option switch component
- add check box component for boolean options
- implement map selection screen with MapView
- support map selection and more fields in order form
- add react-native-maps to mobile app dependencies
- register new screens in navigation

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68594821d4f08324b3ae051d8c7f35dc