### PR TITLE
Improve order card info and address parsing

### DIFF
--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -95,6 +95,9 @@ export default function CreateOrderScreen({ navigation }) {
         fd.append('dropoffLat', dropoff.lat);
         fd.append('dropoffLon', dropoff.lon);
       }
+      if (pickup?.city) {
+        fd.append('city', pickup.city);
+      }
       fd.append('cargoType', description);
       fd.append('dimensions', `${length}x${width}x${height}`);
       fd.append('weight', weight || '0');
@@ -186,7 +189,7 @@ export default function CreateOrderScreen({ navigation }) {
       const res = await fetch(
         `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
           text
-        )}&format=json&limit=5&countrycodes=ua`,
+        )}&format=json&limit=5&countrycodes=ua&addressdetails=1`,
         { headers: { 'User-Agent': 'vango-app' } }
       );
       const data = await res.json();
@@ -240,10 +243,13 @@ export default function CreateOrderScreen({ navigation }) {
                   key={item.place_id}
                   style={styles.suggestionItem}
                   onPress={() => {
+                    const addr = item.address || {};
                     setPickup({
                       text: item.display_name,
                       lat: item.lat,
                       lon: item.lon,
+                      city: addr.city || addr.town || addr.village || addr.state || '',
+                      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
                     });
                     setPickupQuery(item.display_name);
                     setPickupSuggestions([]);
@@ -300,10 +306,13 @@ export default function CreateOrderScreen({ navigation }) {
                   key={item.place_id}
                   style={styles.suggestionItem}
                   onPress={() => {
+                    const addr = item.address || {};
                     setDropoff({
                       text: item.display_name,
                       lat: item.lat,
                       lon: item.lon,
+                      city: addr.city || addr.town || addr.village || addr.state || '',
+                      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
                     });
                     setDropoffQuery(item.display_name);
                     setPickupSuggestions([]);

--- a/mobile-app/src/screens/MapSelectScreen.js
+++ b/mobile-app/src/screens/MapSelectScreen.js
@@ -39,12 +39,17 @@ export default function MapSelectScreen({ navigation, route }) {
     if (onSelect && marker) {
       try {
         const res = await fetch(
-          `https://nominatim.openstreetmap.org/reverse?lat=${marker.latitude}&lon=${marker.longitude}&format=json`,
+          `https://nominatim.openstreetmap.org/reverse?lat=${marker.latitude}&lon=${marker.longitude}&format=json&addressdetails=1`,
           { headers: { 'User-Agent': 'vango-app' } }
         );
         const data = await res.json();
         const text = data.display_name || '';
-        onSelect({ lat: marker.latitude, lon: marker.longitude, text });
+        const addr = data.address || {};
+        const city = addr.city || addr.town || addr.village || addr.state || '';
+        const shortAddress = [addr.road, addr.house_number]
+          .filter(Boolean)
+          .join(' ');
+        onSelect({ lat: marker.latitude, lon: marker.longitude, text, city, address: shortAddress });
       } catch {
         onSelect({ lat: marker.latitude, lon: marker.longitude });
       }

--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -23,16 +23,20 @@ export default function MyOrdersScreen({ navigation }) {
   }, []);
 
   function renderItem({ item }) {
+    const pickupParts = (item.pickupLocation || '').split(',');
+    const dropoffParts = (item.dropoffLocation || '').split(',');
+    const pickupCity = pickupParts.length > 1 ? pickupParts[1].trim() : pickupParts[0];
+    const dropoffCity = dropoffParts.length > 1 ? dropoffParts[1].trim() : dropoffParts[0];
+    const dropoffAddress = dropoffParts[0] ? dropoffParts[0].trim() : '';
     return (
       <TouchableOpacity onPress={() => navigation.navigate('OrderDetail', { order: item, token })}>
         <View style={styles.item}>
-          <Text style={styles.route}>
-            {item.pickupLocation} ➔ {item.dropoffLocation}
-          </Text>
-          <Text style={styles.status}>
-            {new Date(item.loadFrom).toLocaleString()} • {Math.round(item.price)} грн
-          </Text>
-          <Text style={styles.status}>{item.status}</Text>
+          <Text style={styles.itemNumber}>№ {item.id}</Text>
+          <Text style={styles.itemText}>Місто завантаження: {pickupCity}</Text>
+          <Text style={styles.itemText}>Місто розвантаження: {dropoffCity}</Text>
+          <Text style={styles.itemText}>Адреса розвантаження: {dropoffAddress}</Text>
+          <Text style={styles.itemText}>Дата створення: {new Date(item.createdAt).toLocaleDateString()}</Text>
+          <Text style={styles.itemText}>Ціна: {Math.round(item.price)} грн</Text>
         </View>
       </TouchableOpacity>
     );
@@ -76,8 +80,8 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
-  route: { fontSize: 16, fontWeight: '500', color: '#333' },
-  status: { color: '#666', marginTop: 4 },
+  itemNumber: { fontSize: 16, fontWeight: 'bold', marginBottom: 4 },
+  itemText: { color: '#333', marginTop: 2 },
   filters: { flexDirection: 'row', justifyContent: 'space-around', margin: 8 },
   filterBtn: { paddingVertical: 6, paddingHorizontal: 12, borderRadius: 16, borderWidth: 1 },
   activeFilter: { backgroundColor: '#333' },


### PR DESCRIPTION
## Summary
- show pickup/dropoff cities on My Orders card
- include short dropoff address and creation date
- fetch address details from Nominatim and pass city info
- send city when creating an order

## Testing
- `npm run test --prefix mobile-app` *(fails: Missing script)*
- `npm run lint --prefix mobile-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a54f214a4832499511e27409f12e7