### PR TITLE
Improve address fields storage

### DIFF
--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -89,11 +89,19 @@ export default function CreateOrderScreen({ navigation }) {
         fd.append('pickupLocation', pickup.text);
         fd.append('pickupLat', pickup.lat);
         fd.append('pickupLon', pickup.lon);
+        if (pickup.city) fd.append('pickupCity', pickup.city);
+        if (pickup.address) fd.append('pickupAddress', pickup.address);
+        if (pickup.country) fd.append('pickupCountry', pickup.country);
+        if (pickup.postcode) fd.append('pickupPostcode', pickup.postcode);
       }
       if (dropoff) {
         fd.append('dropoffLocation', dropoff.text);
         fd.append('dropoffLat', dropoff.lat);
         fd.append('dropoffLon', dropoff.lon);
+        if (dropoff.city) fd.append('dropoffCity', dropoff.city);
+        if (dropoff.address) fd.append('dropoffAddress', dropoff.address);
+        if (dropoff.country) fd.append('dropoffCountry', dropoff.country);
+        if (dropoff.postcode) fd.append('dropoffPostcode', dropoff.postcode);
       }
       fd.append('cargoType', description);
       fd.append('dimensions', `${length}x${width}x${height}`);
@@ -186,7 +194,7 @@ export default function CreateOrderScreen({ navigation }) {
       const res = await fetch(
         `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
           text
-        )}&format=json&limit=5&countrycodes=ua`,
+        )}&format=json&limit=5&countrycodes=ua&addressdetails=1`,
         { headers: { 'User-Agent': 'vango-app' } }
       );
       const data = await res.json();
@@ -240,10 +248,15 @@ export default function CreateOrderScreen({ navigation }) {
                   key={item.place_id}
                   style={styles.suggestionItem}
                   onPress={() => {
+                    const addr = item.address || {};
                     setPickup({
                       text: item.display_name,
                       lat: item.lat,
                       lon: item.lon,
+                      city: addr.city || addr.town || addr.village || addr.state || '',
+                      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
+                      country: addr.country || '',
+                      postcode: addr.postcode || '',
                     });
                     setPickupQuery(item.display_name);
                     setPickupSuggestions([]);
@@ -300,10 +313,15 @@ export default function CreateOrderScreen({ navigation }) {
                   key={item.place_id}
                   style={styles.suggestionItem}
                   onPress={() => {
+                    const addr = item.address || {};
                     setDropoff({
                       text: item.display_name,
                       lat: item.lat,
                       lon: item.lon,
+                      city: addr.city || addr.town || addr.village || addr.state || '',
+                      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
+                      country: addr.country || '',
+                      postcode: addr.postcode || '',
                     });
                     setDropoffQuery(item.display_name);
                     setPickupSuggestions([]);

--- a/mobile-app/src/screens/MapSelectScreen.js
+++ b/mobile-app/src/screens/MapSelectScreen.js
@@ -39,12 +39,25 @@ export default function MapSelectScreen({ navigation, route }) {
     if (onSelect && marker) {
       try {
         const res = await fetch(
-          `https://nominatim.openstreetmap.org/reverse?lat=${marker.latitude}&lon=${marker.longitude}&format=json`,
+          `https://nominatim.openstreetmap.org/reverse?lat=${marker.latitude}&lon=${marker.longitude}&format=json&addressdetails=1`,
           { headers: { 'User-Agent': 'vango-app' } }
         );
         const data = await res.json();
         const text = data.display_name || '';
-        onSelect({ lat: marker.latitude, lon: marker.longitude, text });
+        const addr = data.address || {};
+        const city = addr.city || addr.town || addr.village || addr.state || '';
+        const shortAddress = [addr.road, addr.house_number]
+          .filter(Boolean)
+          .join(' ');
+        onSelect({
+          lat: marker.latitude,
+          lon: marker.longitude,
+          text,
+          city,
+          address: shortAddress,
+          country: addr.country || '',
+          postcode: addr.postcode || '',
+        });
       } catch {
         onSelect({ lat: marker.latitude, lon: marker.longitude });
       }

--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -23,16 +23,18 @@ export default function MyOrdersScreen({ navigation }) {
   }, []);
 
   function renderItem({ item }) {
+    const pickupCity = item.pickupCity || ((item.pickupLocation || '').split(',')[1] || '').trim();
+    const dropoffCity = item.dropoffCity || ((item.dropoffLocation || '').split(',')[1] || '').trim();
+    const dropoffAddress = item.dropoffAddress || ((item.dropoffLocation || '').split(',')[0] || '').trim();
     return (
       <TouchableOpacity onPress={() => navigation.navigate('OrderDetail', { order: item, token })}>
         <View style={styles.item}>
-          <Text style={styles.route}>
-            {item.pickupLocation} ➔ {item.dropoffLocation}
-          </Text>
-          <Text style={styles.status}>
-            {new Date(item.loadFrom).toLocaleString()} • {Math.round(item.price)} грн
-          </Text>
-          <Text style={styles.status}>{item.status}</Text>
+          <Text style={styles.itemNumber}>№ {item.id}</Text>
+          <Text style={styles.itemText}>Місто завантаження: {pickupCity}</Text>
+          <Text style={styles.itemText}>Місто розвантаження: {dropoffCity}</Text>
+          <Text style={styles.itemText}>Адреса розвантаження: {dropoffAddress}</Text>
+          <Text style={styles.itemText}>Дата створення: {new Date(item.createdAt).toLocaleDateString()}</Text>
+          <Text style={styles.itemText}>Ціна: {Math.round(item.price)} грн</Text>
         </View>
       </TouchableOpacity>
     );
@@ -76,8 +78,8 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
-  route: { fontSize: 16, fontWeight: '500', color: '#333' },
-  status: { color: '#666', marginTop: 4 },
+  itemNumber: { fontSize: 16, fontWeight: 'bold', marginBottom: 4 },
+  itemText: { color: '#333', marginTop: 2 },
   filters: { flexDirection: 'row', justifyContent: 'space-around', margin: 8 },
   filterBtn: { paddingVertical: 6, paddingHorizontal: 12, borderRadius: 16, borderWidth: 1 },
   activeFilter: { backgroundColor: '#333' },

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -6,6 +6,14 @@ async function createOrder(req, res) {
   const {
     pickupLocation,
     dropoffLocation,
+    pickupCountry,
+    pickupCity,
+    pickupAddress,
+    pickupPostcode,
+    dropoffCountry,
+    dropoffCity,
+    dropoffAddress,
+    dropoffPostcode,
     cargoType,
     dimensions,
     weight,
@@ -22,7 +30,6 @@ async function createOrder(req, res) {
     unloadHelp,
     payment,
     insurance,
-    city,
   } = req.body;
   let systemPrice = 0;
   let price = 0;
@@ -42,6 +49,14 @@ async function createOrder(req, res) {
       customerId: req.user.id,
       pickupLocation,
       dropoffLocation,
+      pickupCountry,
+      pickupCity,
+      pickupAddress,
+      pickupPostcode,
+      dropoffCountry,
+      dropoffCity,
+      dropoffAddress,
+      dropoffPostcode,
       cargoType,
       dimensions,
       weight,
@@ -60,7 +75,6 @@ async function createOrder(req, res) {
       insurance,
       systemPrice,
       price,
-      city,
       photos: req.files ? req.files.map((f) => `/uploads/${f.filename}`) : [],
     });
     res.json(order);
@@ -73,7 +87,7 @@ async function createOrder(req, res) {
 async function listAvailableOrders(req, res) {
   const city = req.query.city;
   const where = { status: 'CREATED' };
-  if (city) where.city = city;
+  if (city) where.pickupCity = city;
   const orders = await Order.findAll({ where });
   const takenOrders = await Order.findAll({ where: { status: 'ACCEPTED' }, limit: Math.floor(orders.length / 15) });
   res.json({ available: orders, taken: takenOrders });

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -19,6 +19,14 @@ Order.init(
     driverId: { type: DataTypes.INTEGER.UNSIGNED },
     pickupLocation: { type: DataTypes.STRING, allowNull: false },
     dropoffLocation: { type: DataTypes.STRING, allowNull: false },
+    pickupCountry: { type: DataTypes.STRING },
+    pickupCity: { type: DataTypes.STRING },
+    pickupAddress: { type: DataTypes.STRING },
+    pickupPostcode: { type: DataTypes.STRING },
+    dropoffCountry: { type: DataTypes.STRING },
+    dropoffCity: { type: DataTypes.STRING },
+    dropoffAddress: { type: DataTypes.STRING },
+    dropoffPostcode: { type: DataTypes.STRING },
     cargoType: { type: DataTypes.STRING, allowNull: false },
     dimensions: { type: DataTypes.STRING, allowNull: false },
     weight: { type: DataTypes.FLOAT, allowNull: false },
@@ -39,7 +47,6 @@ Order.init(
     systemPrice: { type: DataTypes.FLOAT, allowNull: false, defaultValue: 0 },
     price: { type: DataTypes.FLOAT, allowNull: false },
     photos: { type: DataTypes.JSON },
-    city: { type: DataTypes.STRING },
   },
   { sequelize: db, modelName: 'order' }
 );

--- a/src/seed.js
+++ b/src/seed.js
@@ -18,6 +18,14 @@ async function seed() {
     pickupLon: -74.006,
     dropoffLat: 40.73,
     dropoffLon: -74.1,
+    pickupCountry: 'USA',
+    pickupCity: 'New York',
+    pickupAddress: 'A',
+    pickupPostcode: '10001',
+    dropoffCountry: 'USA',
+    dropoffCity: 'New York',
+    dropoffAddress: 'B',
+    dropoffPostcode: '10002',
     cargoType: 'Boxes',
     dimensions: '1x1x1',
     weight: 100,
@@ -33,7 +41,6 @@ async function seed() {
     systemPrice: 100,
     price: 100,
     photos: [],
-    city: 'NYC',
   });
 
   console.log('Seeded');


### PR DESCRIPTION
## Summary
- store pickup and dropoff country, city, address, and postcode in the Order model
- include those fields when creating orders on the server
- capture detailed address info from map and search suggestions
- send the new fields when creating an order
- display new address fields on My Orders cards

## Testing
- `npm run test --prefix mobile-app` *(fails: Missing script)*
- `npm run lint --prefix mobile-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a54f214a4832499511e27409f12e7