### PR TITLE
Ensure role-specific orders

### DIFF
--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -4,15 +4,16 @@ import { apiFetch } from '../api';
 import { useAuth } from '../AuthContext';
 
 export default function MyOrdersScreen({ navigation }) {
-  const { token } = useAuth();
+  const { token, role } = useAuth();
   const [orders, setOrders] = useState([]);
   const [filter, setFilter] = useState('active');
 
   useEffect(() => {
     async function load() {
       try {
-        const data = await apiFetch('/orders/my', {
-          headers: { Authorization: `Bearer ${token}` }
+        const url = role ? `/orders/my?role=${role}` : '/orders/my';
+        const data = await apiFetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
         });
         setOrders(data);
       } catch (err) {
@@ -20,7 +21,7 @@ export default function MyOrdersScreen({ navigation }) {
       }
     }
     load();
-  }, []);
+  }, [role]);
 
   function renderItem({ item }) {
     const pickupCity = item.pickupCity || ((item.pickupLocation || '').split(',')[1] || '').trim();

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -95,12 +95,13 @@ async function listAvailableOrders(req, res) {
 
 async function listMyOrders(req, res) {
   const { Op } = require('sequelize');
+  const role = req.query.role || req.user.role;
   let where = {};
-  if (req.user.role === 'CUSTOMER') {
+  if (role === 'CUSTOMER') {
     where.customerId = req.user.id;
-  } else if (req.user.role === 'DRIVER') {
+  } else if (role === 'DRIVER') {
     where.driverId = req.user.id;
-  } else if (req.user.role === 'BOTH') {
+  } else if (role === 'BOTH' || !role) {
     where = {
       [Op.or]: [{ customerId: req.user.id }, { driverId: req.user.id }],
     };


### PR DESCRIPTION
## Summary
- allow `role` query param for orders
- filter orders by driver or customer role on frontend

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a5ddb26e08324a63935d038138d8a