### PR TITLE
Fix layout of order pages

### DIFF
--- a/mobile-app/src/api.js
+++ b/mobile-app/src/api.js
@@ -1,4 +1,5 @@
-export const API_URL = 'http://78.137.7.91:20004/api';
+export const HOST_URL = 'http://78.137.7.91:20004';
+export const API_URL = `${HOST_URL}/api`;
 
 export async function apiFetch(path, options = {}) {
   const headers = options.headers || {};

--- a/mobile-app/src/screens/EditOrderScreen.js
+++ b/mobile-app/src/screens/EditOrderScreen.js
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   Alert,
   ScrollView,
+  SafeAreaView,
 } from 'react-native';
 import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
@@ -18,7 +19,7 @@ import PhotoPicker from '../components/PhotoPicker';
 import OptionSwitch from '../components/OptionSwitch';
 import CheckBox from '../components/CheckBox';
 import { Ionicons } from '@expo/vector-icons';
-import { apiFetch, API_URL } from '../api';
+import { apiFetch, API_URL, HOST_URL } from '../api';
 import { useAuth } from '../AuthContext';
 
 export default function EditOrderScreen({ route, navigation }) {
@@ -74,7 +75,7 @@ export default function EditOrderScreen({ route, navigation }) {
   const [unloadFrom, setUnloadFrom] = useState(new Date(order.unloadFrom));
   const [unloadTo, setUnloadTo] = useState(new Date(order.unloadTo));
   const [photos, setPhotos] = useState(
-    order.photos ? order.photos.map((p) => `${API_URL}${p}`) : []
+    order.photos ? order.photos.map((p) => `${HOST_URL}${p}`) : []
   );
   const [description, setDescription] = useState(order.cargoType || '');
   const [systemPrice, setSystemPrice] = useState(order.systemPrice || null);
@@ -148,12 +149,14 @@ export default function EditOrderScreen({ route, navigation }) {
       const finalPrice = Math.round((systemPrice || 0) * (1 + adjust / 100));
       fd.append('price', finalPrice.toString());
       if (photos && photos.length > 0) {
-        photos.forEach((p) => {
-          const filename = p.split('/').pop();
-          const match = /\.([a-zA-Z0-9]+)$/.exec(filename || '');
-          const type = match ? `image/${match[1]}` : 'image';
-          fd.append('photos', { uri: p, name: filename, type });
-        });
+        photos
+          .filter((p) => !p.startsWith('http'))
+          .forEach((p) => {
+            const filename = p.split('/').pop();
+            const match = /\.([a-zA-Z0-9]+)$/.exec(filename || '');
+            const type = match ? `image/${match[1]}` : 'image';
+            fd.append('photos', { uri: p, name: filename, type });
+          });
       }
       const updated = await apiFetch(`/orders/${order.id}`, {
         method: 'PATCH',
@@ -218,7 +221,7 @@ export default function EditOrderScreen({ route, navigation }) {
 
 
   return (
-    <View style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }}>
       <TouchableOpacity style={styles.back} onPress={() => navigation.goBack()}>
         <Ionicons name="arrow-back" size={32} color="#333" />
       </TouchableOpacity>
@@ -452,12 +455,12 @@ export default function EditOrderScreen({ route, navigation }) {
 
       <AppButton title="Зберегти" onPress={confirmSave} />
     </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { padding: 16 },
+  container: { padding: 16, paddingTop: 24 },
   dim: { flex: 1 },
   suggestionsBox: {
     backgroundColor: '#fff',


### PR DESCRIPTION
## Summary
- add HOST_URL constant for correct file URLs
- show order details in SafeAreaView and add spacing
- load photos via HOST_URL and use SafeAreaView on edit screen
- avoid re-uploading existing photos when editing
- modernize detail screen layout and allow full image preview

## Testing
- `npm install --silent` *(fails: no output)*
- `cd mobile-app && npm install --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685a674904008324bebf9eb9ebdbb63a