### PR TITLE
Implement order reservation

### DIFF
--- a/mobile-app/src/screens/RegisterScreen.js
+++ b/mobile-app/src/screens/RegisterScreen.js
@@ -15,6 +15,7 @@ export default function RegisterScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [city, setCity] = useState('');
+  const [phone, setPhone] = useState('');
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -23,6 +24,7 @@ export default function RegisterScreen({ navigation }) {
       setEmail('');
       setPassword('');
       setCity('');
+      setPhone('');
       setError(null);
     });
     return unsubscribe;
@@ -37,7 +39,7 @@ export default function RegisterScreen({ navigation }) {
     try {
       await apiFetch('/auth/register', {
         method: 'POST',
-        body: JSON.stringify({ name, email, password, city }),
+        body: JSON.stringify({ name, email, password, city, phone }),
       });
       toast.show('Реєстрація успішна');
       navigation.goBack();
@@ -66,6 +68,8 @@ export default function RegisterScreen({ navigation }) {
         onChangeText={setPassword}
         placeholder="********"
       />
+      <AppText style={styles.label}>Телефон</AppText>
+      <AppInput value={phone} onChangeText={setPhone} placeholder="380..." keyboardType="phone-pad" />
       <AppText style={styles.label}>Місто</AppText>
       <AppInput value={city} onChangeText={setCity} placeholder="Київ" />
       {error && <AppText style={styles.error}>{error}</AppText>}

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -5,10 +5,10 @@ const { UserRole } = require('../models/user');
 const { JWT_SECRET } = require('../config');
 
 async function register(req, res) {
-  const { name, email, password, city } = req.body;
+  const { name, email, password, city, phone } = req.body;
   try {
     const hashed = await bcrypt.hash(password, 10);
-    const user = await User.create({ name, email, password: hashed, city });
+    const user = await User.create({ name, email, password: hashed, city, phone });
     res.json(user);
   } catch (err) {
     res.status(400).send('Помилка реєстрації');

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -46,6 +46,8 @@ Order.init(
     status: { type: DataTypes.ENUM(...Object.values(OrderStatus)), defaultValue: OrderStatus.CREATED },
     systemPrice: { type: DataTypes.FLOAT, allowNull: false, defaultValue: 0 },
     price: { type: DataTypes.FLOAT, allowNull: false },
+    reservedBy: { type: DataTypes.INTEGER.UNSIGNED },
+    reservedUntil: { type: DataTypes.DATE },
     photos: { type: DataTypes.JSON },
   },
   { sequelize: db, modelName: 'order' }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -28,6 +28,7 @@ User.init(
     rating: { type: DataTypes.FLOAT, defaultValue: 5 },
     blocked: { type: DataTypes.BOOLEAN, defaultValue: false },
     city: { type: DataTypes.STRING },
+    phone: { type: DataTypes.STRING },
     balance: { type: DataTypes.FLOAT, defaultValue: 0 },
   },
   {

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -4,6 +4,8 @@ const { upload } = require('../middlewares/upload');
 const {
   createOrder,
   listAvailableOrders,
+  reserveOrder,
+  cancelReserve,
   acceptOrder,
   updateStatus,
   listMyOrders,
@@ -16,6 +18,8 @@ const router = Router();
 
 router.post('/', authenticate, authorize([UserRole.CUSTOMER]), upload.array('photos', 10), createOrder);
 router.get('/', authenticate, authorize([UserRole.DRIVER]), listAvailableOrders);
+router.post('/:id/reserve', authenticate, authorize([UserRole.DRIVER]), reserveOrder);
+router.post('/:id/cancel-reserve', authenticate, authorize([UserRole.DRIVER]), cancelReserve);
 router.get('/my', authenticate, listMyOrders);
 router.post('/:id/accept', authenticate, authorize([UserRole.DRIVER]), acceptOrder);
 router.patch('/:id/status', authenticate, updateStatus);

--- a/src/seed.js
+++ b/src/seed.js
@@ -6,9 +6,9 @@ const Order = require('./models/order');
 async function seed() {
   await db.sync({ force: true });
 
-  const customer = await User.create({ name: 'Alice', email: 'alice@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC' });
-  const driver = await User.create({ name: 'Bob', email: 'bob@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC' });
-  await User.create({ name: 'Admin', email: 'admin@example.com', password: 'admin', role: UserRole.ADMIN });
+  const customer = await User.create({ name: 'Alice', email: 'alice@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC', phone: '380000000001' });
+  const driver = await User.create({ name: 'Bob', email: 'bob@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC', phone: '380000000002' });
+  await User.create({ name: 'Admin', email: 'admin@example.com', password: 'admin', role: UserRole.ADMIN, phone: '380000000003' });
 
   await Order.create({
     customerId: customer.id,


### PR DESCRIPTION
## Summary
- allow registering with phone number
- add phone column in user model
- support reserving orders in backend and hide reserved orders
- expose reservation API routes
- add reservation UI in order details screen

## Testing
- `npm install`
- `npm run dev` *(fails: Cannot read properties of null (reading 'replace'))*

------
https://chatgpt.com/codex/tasks/task_e_685a9c11ac2883248f36b40192738eb5