### PR TITLE
Improve order info display

### DIFF
--- a/mobile-app/src/components/OrderCard.js
+++ b/mobile-app/src/components/OrderCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import MapView, { Marker } from 'react-native-maps';
 import { colors } from './Colors';
 
@@ -55,6 +56,29 @@ export default function OrderCard({ order, onPress }) {
           Обʼєм: {volume !== null ? volume.toFixed(2) : '?'} м³, Вага: {order.weight} кг
         </Text>
         <Text style={styles.info}>Ціна: {Math.round(order.price)} грн</Text>
+        <View style={styles.iconRow}>
+          <Ionicons
+            name={order.payment === 'card' ? 'card' : 'cash'}
+            size={20}
+            color={colors.green}
+          />
+          {order.loadHelp && (
+            <Ionicons
+              name="arrow-down-circle-outline"
+              size={20}
+              color={colors.orange}
+              style={{ marginLeft: 8 }}
+            />
+          )}
+          {order.unloadHelp && (
+            <Ionicons
+              name="arrow-up-circle-outline"
+              size={20}
+              color={colors.orange}
+              style={{ marginLeft: 4 }}
+            />
+          )}
+        </View>
       </TouchableOpacity>
     </View>
   );
@@ -85,4 +109,5 @@ const styles = StyleSheet.create({
   infoContainer: { paddingVertical: 4 },
   route: { fontWeight: 'bold', marginTop: 8 },
   info: { marginTop: 2, color: '#333' },
+  iconRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
 });

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -19,6 +19,12 @@ import { apiFetch, HOST_URL } from '../api';
 import { colors } from '../components/Colors';
 import { useAuth } from '../AuthContext';
 
+function formatDateTime(dateStr) {
+  const d = new Date(dateStr);
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export default function OrderDetailScreen({ route, navigation }) {
   const { order } = route.params;
   const [previewIndex, setPreviewIndex] = useState(null);
@@ -199,9 +205,39 @@ export default function OrderDetailScreen({ route, navigation }) {
         <Text style={styles.value}>{order.weight}</Text>
       </View>
       <View style={styles.row}>
+        <Text style={styles.label}>Завантаження:</Text>
+        <Text style={styles.value}>
+          {formatDateTime(order.loadFrom)} - {formatDateTime(order.loadTo)}
+        </Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Вивантаження:</Text>
+        <Text style={styles.value}>
+          {formatDateTime(order.unloadFrom)} - {formatDateTime(order.unloadTo)}
+        </Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Оплата:</Text>
+        <Text style={styles.value}>{order.payment === 'card' ? 'Карта' : 'Готівка'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Завантаження допомога:</Text>
+        <Text style={styles.value}>{order.loadHelp ? 'так' : 'ні'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Розвантаження допомога:</Text>
+        <Text style={styles.value}>{order.unloadHelp ? 'так' : 'ні'}</Text>
+      </View>
+      <View style={styles.row}>
         <Text style={styles.label}>Ціна:</Text>
         <Text style={styles.value}>{Math.round(order.price)} грн</Text>
       </View>
+      {order.cargoType && (
+        <View style={styles.row}>
+          <Text style={styles.label}>Опис:</Text>
+          <Text style={styles.value}>{order.cargoType}</Text>
+        </View>
+      )}
       {order.photos && order.photos.length > 0 && (
         <ScrollView horizontal style={{ marginVertical: 8 }}>
           {order.photos.map((p, i) => (


### PR DESCRIPTION
## Summary
- add icons for payment and load/unload help in order cards
- show missing fields like load/unload times, payment and help flags in OrderDetailScreen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab1675c048324b660bfd93ae33c31