### PR TITLE
Improve order info display

### DIFF
--- a/mobile-app/src/components/OrderCard.js
+++ b/mobile-app/src/components/OrderCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import MapView, { Marker } from 'react-native-maps';
 import { colors } from './Colors';
 
@@ -55,6 +56,29 @@ export default function OrderCard({ order, onPress }) {
           Обʼєм: {volume !== null ? volume.toFixed(2) : '?'} м³, Вага: {order.weight} кг
         </Text>
         <Text style={styles.info}>Ціна: {Math.round(order.price)} грн</Text>
+        <View style={styles.iconRow}>
+          <Ionicons
+            name={order.payment === 'card' ? 'card' : 'cash'}
+            size={20}
+            color={colors.green}
+          />
+          {order.loadHelp && (
+            <Ionicons
+              name="arrow-down-circle-outline"
+              size={20}
+              color={colors.orange}
+              style={{ marginLeft: 8 }}
+            />
+          )}
+          {order.unloadHelp && (
+            <Ionicons
+              name="arrow-up-circle-outline"
+              size={20}
+              color={colors.orange}
+              style={{ marginLeft: 4 }}
+            />
+          )}
+        </View>
       </TouchableOpacity>
     </View>
   );
@@ -85,4 +109,5 @@ const styles = StyleSheet.create({
   infoContainer: { paddingVertical: 4 },
   route: { fontWeight: 'bold', marginTop: 8 },
   info: { marginTop: 2, color: '#333' },
+  iconRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
 });

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -19,6 +19,18 @@ import { apiFetch, HOST_URL } from '../api';
 import { colors } from '../components/Colors';
 import { useAuth } from '../AuthContext';
 
+function formatTime(dateStr) {
+  const d = new Date(dateStr);
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
 export default function OrderDetailScreen({ route, navigation }) {
   const { order } = route.params;
   const [previewIndex, setPreviewIndex] = useState(null);
@@ -166,6 +178,15 @@ export default function OrderDetailScreen({ route, navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
+      {reserved && timeLeft !== null && (
+        <View style={styles.fixedTimer}>
+          <Text style={styles.timerText}>
+            {String(Math.floor(timeLeft / 60000)).padStart(2, '0')}:
+            {String(Math.floor((timeLeft % 60000) / 1000)).padStart(2, '0')}
+          </Text>
+        </View>
+      )}
+      <ScrollView contentContainerStyle={{ paddingBottom: 16 }}>
       <View style={styles.actions}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.iconButton}>
           <Ionicons name="arrow-back" size={28} color="#333" />
@@ -182,26 +203,68 @@ export default function OrderDetailScreen({ route, navigation }) {
         )}
       </View>
       <Text style={styles.title}>Замовлення № {order.id}</Text>
+      <View style={styles.detailsCard}>
       <View style={styles.row}>
+        <Ionicons name="pin-outline" size={20} color={colors.orange} style={styles.rowIcon} />
         <Text style={styles.label}>Звідки:</Text>
         <Text style={styles.value}>{order.pickupLocation}</Text>
       </View>
       <View style={styles.row}>
+        <Ionicons name="flag-outline" size={20} color={colors.green} style={styles.rowIcon} />
         <Text style={styles.label}>Куди:</Text>
         <Text style={styles.value}>{order.dropoffLocation}</Text>
       </View>
       <View style={styles.row}>
+        <Ionicons name="cube-outline" size={20} color="#555" style={styles.rowIcon} />
         <Text style={styles.label}>Габарити:</Text>
         <Text style={styles.value}>{order.dimensions}</Text>
       </View>
       <View style={styles.row}>
+        <Ionicons name="fitness-outline" size={20} color="#555" style={styles.rowIcon} />
         <Text style={styles.label}>Вага:</Text>
         <Text style={styles.value}>{order.weight}</Text>
       </View>
       <View style={styles.row}>
+        <Ionicons name="time-outline" size={20} color="#555" style={styles.rowIcon} />
+        <Text style={styles.label}>Завантаження:</Text>
+        <Text style={styles.value}>
+          {formatDate(order.loadFrom)} {formatTime(order.loadFrom)} - {formatTime(order.loadTo)}
+        </Text>
+      </View>
+      <View style={styles.row}>
+        <Ionicons name="time-outline" size={20} color="#555" style={styles.rowIcon} />
+        <Text style={styles.label}>Вивантаження:</Text>
+        <Text style={styles.value}>
+          {formatDate(order.unloadFrom)} {formatTime(order.unloadFrom)} - {formatTime(order.unloadTo)}
+        </Text>
+      </View>
+      <View style={styles.row}>
+        <Ionicons name={order.payment === 'card' ? 'card-outline' : 'cash-outline'} size={20} color="#555" style={styles.rowIcon} />
+        <Text style={styles.label}>Оплата:</Text>
+        <Text style={styles.value}>{order.payment === 'card' ? 'Карта' : 'Готівка'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Ionicons name="arrow-down-circle-outline" size={20} color={colors.orange} style={styles.rowIcon} />
+        <Text style={styles.label}>Завантаження допомога:</Text>
+        <Text style={styles.value}>{order.loadHelp ? 'так' : 'ні'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Ionicons name="arrow-up-circle-outline" size={20} color={colors.orange} style={styles.rowIcon} />
+        <Text style={styles.label}>Розвантаження допомога:</Text>
+        <Text style={styles.value}>{order.unloadHelp ? 'так' : 'ні'}</Text>
+      </View>
+      <View style={styles.row}>
+        <Ionicons name="pricetag-outline" size={20} color="#555" style={styles.rowIcon} />
         <Text style={styles.label}>Ціна:</Text>
         <Text style={styles.value}>{Math.round(order.price)} грн</Text>
       </View>
+      {order.cargoType && (
+        <View style={styles.row}>
+          <Ionicons name="reader-outline" size={20} color="#555" style={styles.rowIcon} />
+          <Text style={styles.label}>Опис:</Text>
+          <Text style={styles.value}>{order.cargoType}</Text>
+        </View>
+      )}
       {order.photos && order.photos.length > 0 && (
         <ScrollView horizontal style={{ marginVertical: 8 }}>
           {order.photos.map((p, i) => (
@@ -225,6 +288,7 @@ export default function OrderDetailScreen({ route, navigation }) {
           </View>
         </Modal>
       )}
+      </View>
       {role === 'DRIVER' && !order.driverId && (
         <View style={styles.bottomButtons}>
           {!reserved && <AppButton title="Резерв 10 хв" onPress={reserve} />}
@@ -250,6 +314,7 @@ export default function OrderDetailScreen({ route, navigation }) {
         </View>
       )}
       {order.driverId && <Button title="У вибране" onPress={addFavorite} />}
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -262,6 +327,18 @@ const styles = StyleSheet.create({
   row: { flexDirection: 'row', marginBottom: 8, alignItems: 'center' },
   label: { fontWeight: 'bold', marginRight: 8, fontSize: 16 },
   value: { fontSize: 16, flexShrink: 1 },
+  rowIcon: { marginRight: 6 },
+  detailsCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 2,
+  },
   photo: { width: 120, height: 120, marginRight: 8 },
   modal: { flex: 1, backgroundColor: 'black', justifyContent: 'center', alignItems: 'center' },
   full: { width: '100%', height: '100%' },
@@ -276,5 +353,17 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   timer: { textAlign: 'right', fontSize: 16, color: colors.orange },
+  fixedTimer: {
+    position: 'absolute',
+    top: 8,
+    right: 16,
+    backgroundColor: '#fff',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    elevation: 3,
+    zIndex: 2,
+  },
+  timerText: { fontSize: 16, color: colors.orange, fontWeight: 'bold' },
 });
 


### PR DESCRIPTION
## Summary
- add icons and better layout for order details
- show load and unload times as just hours without dates
- show date with times on order details and add scroll with sticky timer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab1675c048324b660bfd93ae33c31