### PR TITLE
Fix filter search to execute on button click

### DIFF
--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -72,7 +72,7 @@ export default function AllOrdersScreen({ navigation }) {
     fetchOrders();
     const unsubscribe = navigation.addListener('focus', fetchOrders);
     return unsubscribe;
-  }, [detected, date, pickupCity, dropoffCity, volume, weight, navigation]);
+  }, [detected, navigation]);
 
   useEffect(() => {
     if (!detected) return;
@@ -80,7 +80,7 @@ export default function AllOrdersScreen({ navigation }) {
     return () => {
       if (wsRef.current) wsRef.current.close();
     };
-  }, [detected, token, date, pickupCity, dropoffCity, volume, weight, radius, location]);
+  }, [detected, token, location]);
 
   async function fetchOrders() {
     try {
@@ -257,6 +257,7 @@ export default function AllOrdersScreen({ navigation }) {
               title="Пошук"
               onPress={() => {
                 fetchOrders();
+                connectWs();
                 setFiltersVisible(false);
               }}
               style={styles.actionBtn}


### PR DESCRIPTION
## Summary
- fix filters triggering automatic fetch when typing
- reconnect websocket when performing search

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b087c2ac48324a18d2b590ea2418f