### PR TITLE
Add websocket updates for order changes

### DIFF
--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -115,6 +115,10 @@ export default function AllOrdersScreen({ navigation }) {
   }
 
   function passesFilters(o) {
+    if (o.deleted) return false;
+    const now = new Date();
+    if (o.status !== 'CREATED') return false;
+    if (o.reservedBy && o.reservedUntil && new Date(o.reservedUntil) > now) return false;
     if (date && formatDate(new Date(o.loadFrom)) !== formatDate(date)) return false;
     if (pickupCity && !(o.pickupCity || '').toLowerCase().includes(pickupCity.toLowerCase())) return false;
     if (dropoffCity && !(o.dropoffCity || '').toLowerCase().includes(dropoffCity.toLowerCase())) return false;
@@ -148,8 +152,13 @@ export default function AllOrdersScreen({ navigation }) {
     ws.onmessage = (ev) => {
       try {
         const order = JSON.parse(ev.data);
-        if (!passesFilters(order)) return;
         setOrders((prev) => {
+          if (order.deleted) {
+            return prev.filter((o) => o.id !== order.id);
+          }
+          if (!passesFilters(order)) {
+            return prev.filter((o) => o.id !== order.id);
+          }
           const idx = prev.findIndex((o) => o.id === order.id);
           if (idx >= 0) {
             const copy = [...prev];

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -1,6 +1,7 @@
 const Order = require('../models/order');
 const Transaction = require('../models/transaction');
 const { SERVICE_FEE_PERCENT } = require('../config');
+const { broadcastOrder, broadcastDelete } = require('../ws');
 
 async function createOrder(req, res) {
   const {
@@ -77,6 +78,7 @@ async function createOrder(req, res) {
       price,
       photos: req.files ? req.files.map((f) => `/uploads/${f.filename}`) : [],
     });
+    broadcastOrder(order);
     res.json(order);
   } catch (err) {
     res.status(400).send('Не вдалося створити замовлення');
@@ -177,6 +179,7 @@ async function reserveOrder(req, res) {
     order.reservedBy = req.user.id;
     order.reservedUntil = new Date(now.getTime() + 10 * 60000);
     await order.save();
+    broadcastOrder(order);
     res.json({ order, phone: order.customer ? order.customer.phone : null });
   } catch (err) {
     res.status(400).send('Не вдалося зарезервувати');
@@ -193,6 +196,7 @@ async function cancelReserve(req, res) {
     order.reservedBy = null;
     order.reservedUntil = null;
     await order.save();
+    broadcastOrder(order);
     res.json(order);
   } catch (err) {
     res.status(400).send('Не вдалося зняти резерв');
@@ -211,6 +215,7 @@ async function acceptOrder(req, res) {
     order.driverId = req.user.id;
     order.status = 'ACCEPTED';
     await order.save();
+    broadcastOrder(order);
     const serviceFee = (order.price * SERVICE_FEE_PERCENT) / 100;
     await Transaction.create({ orderId: order.id, driverId: req.user.id, amount: order.price, serviceFee });
     res.json(order);
@@ -342,6 +347,7 @@ async function deleteOrder(req, res) {
       return res.status(400).send('Неможливо видалити');
     }
     await order.destroy();
+    broadcastDelete(id);
     res.json({ message: 'Deleted' });
   } catch (err) {
     res.status(400).send('Помилка видалення');

--- a/src/ws.js
+++ b/src/ws.js
@@ -6,7 +6,9 @@ const Order = require('./models/order');
 const User = require('./models/user');
 const { Op } = require('sequelize');
 
-function buildWhere(query, userId) {
+let wssInstance;
+
+function buildWhere(query, userId, ignoreReserve = false) {
   const where = { status: 'CREATED' };
   const city = query.pickupCity || query.city;
   if (city) where.pickupCity = city;
@@ -23,17 +25,20 @@ function buildWhere(query, userId) {
     if (query.minWeight) where.weight[Op.gte] = parseFloat(query.minWeight);
     if (query.maxWeight) where.weight[Op.lte] = parseFloat(query.maxWeight);
   }
-  const now = new Date();
-  where[Op.or] = [
-    { reservedBy: null },
-    { reservedUntil: { [Op.lt]: now } },
-    { reservedBy: userId },
-  ];
+  if (!ignoreReserve) {
+    const now = new Date();
+    where[Op.or] = [
+      { reservedBy: null },
+      { reservedUntil: { [Op.lt]: now } },
+      { reservedBy: userId },
+    ];
+  }
   return where;
 }
 
 function setupWebSocket(server) {
   const wss = new WebSocket.Server({ noServer: true });
+  wssInstance = wss;
 
   server.on('upgrade', async (req, socket, head) => {
     const pathname = url.parse(req.url).pathname;
@@ -60,9 +65,10 @@ function setupWebSocket(server) {
     }
 
     const query = url.parse(req.url, true).query;
-    const where = buildWhere(query, req.user.id);
+    const filterWhere = buildWhere(query, req.user.id);
+    const updateWhere = buildWhere(query, req.user.id, true);
 
-    const orders = await Order.findAll({ where });
+    const orders = await Order.findAll({ where: filterWhere });
     for (const o of orders) {
       ws.send(JSON.stringify(o));
     }
@@ -71,7 +77,7 @@ function setupWebSocket(server) {
     const interval = setInterval(async () => {
       const updated = await Order.findAll({
         where: {
-          ...where,
+          ...updateWhere,
           updatedAt: { [Op.gt]: lastCheck },
         },
       });
@@ -83,4 +89,24 @@ function setupWebSocket(server) {
   });
 }
 
-module.exports = { setupWebSocket };
+function broadcastOrder(order) {
+  if (!wssInstance) return;
+  const data = JSON.stringify(order);
+  wssInstance.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  });
+}
+
+function broadcastDelete(id) {
+  if (!wssInstance) return;
+  const data = JSON.stringify({ id, deleted: true });
+  wssInstance.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  });
+}
+
+module.exports = { setupWebSocket, broadcastOrder, broadcastDelete };


### PR DESCRIPTION
## Summary
- broadcast order create/reserve/accept/cancel/delete events via WebSocket
- expose helper functions for broadcasting updates
- filter out unavailable orders on the All Orders screen
- update mobile app to remove orders when they become unavailable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b0b150ef48324a1b6f6fa8304ea87