### PR TITLE
Improve iOS camera permission and layout

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -14,7 +14,11 @@
     },
 
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSCameraUsageDescription": "Доступ до камери потрібен для додавання фото",
+        "NSPhotoLibraryUsageDescription": "Доступ до фото потрібен для вибору з галереї"
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/mobile-app/src/components/DateInput.js
+++ b/mobile-app/src/components/DateInput.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import AppInput from './AppInput';
 
@@ -26,7 +26,13 @@ export default function DateInput({ value, onChange, style }) {
         />
       </TouchableOpacity>
       {showDate && (
-        <DateTimePicker value={value} mode="date" is24Hour onChange={onChangeDate} />
+        <DateTimePicker
+          value={value}
+          mode="date"
+          is24Hour
+          display={Platform.OS === 'ios' ? 'inline' : 'default'}
+          onChange={onChangeDate}
+        />
       )}
     </View>
   );

--- a/mobile-app/src/components/PhotoPicker.js
+++ b/mobile-app/src/components/PhotoPicker.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity, Image, Modal, StyleSheet, ScrollView } from 'react-native';
+import { View, TouchableOpacity, Image, Modal, StyleSheet, ScrollView, Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import AppButton from './AppButton';
@@ -8,6 +8,11 @@ export default function PhotoPicker({ photos, onChange }) {
   const [previewIndex, setPreviewIndex] = useState(null);
 
   async function pickFromLibrary() {
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (perm.status !== 'granted') {
+      Alert.alert('Доступ до фото', 'Надайте доступ до галереї');
+      return;
+    }
     const res = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       quality: 0.5,
@@ -16,6 +21,11 @@ export default function PhotoPicker({ photos, onChange }) {
   }
 
   async function takePhoto() {
+    const perm = await ImagePicker.requestCameraPermissionsAsync();
+    if (perm.status !== 'granted') {
+      Alert.alert('Доступ до камери', 'Надайте доступ до камери');
+      return;
+    }
     const res = await ImagePicker.launchCameraAsync({
       quality: 0.5,
     });

--- a/mobile-app/src/components/TimeInput.js
+++ b/mobile-app/src/components/TimeInput.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import AppInput from './AppInput';
 
@@ -28,7 +28,13 @@ export default function TimeInput({ value, onChange, style }) {
 
       </TouchableOpacity>
       {showTime && (
-        <DateTimePicker value={value} mode="time" is24Hour onChange={onChangeTime} />
+        <DateTimePicker
+          value={value}
+          mode="time"
+          is24Hour
+          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+          onChange={onChangeTime}
+        />
       )}
     </View>
   );

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -294,7 +294,7 @@ function formatDate(d) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: { flex: 1, paddingHorizontal: 12 },
   filters: {
     padding: 16,
   },

--- a/mobile-app/src/screens/FavoriteDriversScreen.js
+++ b/mobile-app/src/screens/FavoriteDriversScreen.js
@@ -52,7 +52,7 @@ export default function FavoriteDriversScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: { flex: 1, paddingHorizontal: 12 },
   item: { padding: 12, borderBottomWidth: 1 },
   skelLine: { height: 20, margin: 12 }
 });

--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -90,7 +90,7 @@ export default function MyOrdersScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: { flex: 1, paddingHorizontal: 12 },
   item: {
     padding: 12,
     marginHorizontal: 12,

--- a/mobile-app/src/screens/OrderListScreen.js
+++ b/mobile-app/src/screens/OrderListScreen.js
@@ -56,7 +56,7 @@ export default function OrderListScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: { flex: 1, paddingHorizontal: 12 },
   item: {
     padding: 12,
     marginHorizontal: 12,


### PR DESCRIPTION
## Summary
- request permissions when using the camera or gallery
- add iOS permission strings in Expo config
- open date/time pickers in calendar/spinner mode on iOS
- add horizontal padding on order screens

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in mobile-app *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_685b11f95c2483249b545d4d892db52b