### PR TITLE
Add photo limits to order creation

### DIFF
--- a/mobile-app/src/components/PhotoPicker.js
+++ b/mobile-app/src/components/PhotoPicker.js
@@ -8,6 +8,10 @@ export default function PhotoPicker({ photos, onChange }) {
   const [previewIndex, setPreviewIndex] = useState(null);
 
   async function pickFromLibrary() {
+    if (photos && photos.length >= 10) {
+      Alert.alert('Ліміт фото', 'Максимум 10 фотографій');
+      return;
+    }
     const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (perm.status !== 'granted') {
       Alert.alert('Доступ до фото', 'Надайте доступ до галереї');
@@ -21,6 +25,10 @@ export default function PhotoPicker({ photos, onChange }) {
   }
 
   async function takePhoto() {
+    if (photos && photos.length >= 10) {
+      Alert.alert('Ліміт фото', 'Максимум 10 фотографій');
+      return;
+    }
     const perm = await ImagePicker.requestCameraPermissionsAsync();
     if (perm.status !== 'granted') {
       Alert.alert('Доступ до камери', 'Надайте доступ до камери');

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -162,6 +162,14 @@ export default function CreateOrderScreen({ navigation }) {
       Alert.alert('Помилка', 'Вкажіть адреси завантаження та розвантаження');
       return;
     }
+    if (!photos || photos.length === 0) {
+      Alert.alert('Помилка', 'Додайте хоча б одне фото вантажу');
+      return;
+    }
+    if (photos.length > 10) {
+      Alert.alert('Помилка', 'Максимальна кількість фото - 10');
+      return;
+    }
     if (systemPrice === null) {
       Alert.alert('Помилка', 'Не вдалося розрахувати ціну');
       return;


### PR DESCRIPTION
## Summary
- enforce photo limit (1-10) when creating orders
- warn user in PhotoPicker when 10-photo limit reached

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bb0ade73c83249691772a91065670