### PR TITLE
Fix driver/customer info display and navigation

### DIFF
--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -106,7 +106,7 @@ export default function MyOrdersScreen({ navigation }) {
     return (
       <TouchableOpacity onPress={() => navigation.navigate('OrderDetail', { order: item, token })}>
         <View style={[styles.item, reserved && styles.reservedItem]}>
-          {reserved && item.customer && (
+          {role === 'DRIVER' && item.customer && (
             <View style={styles.driverBlock}>
               <View style={styles.driverRow}>
                 <Ionicons name="person-circle" size={36} color={colors.green} />
@@ -119,17 +119,44 @@ export default function MyOrdersScreen({ navigation }) {
                   </TouchableOpacity>
                 )}
               </View>
-              <Text style={styles.timerText}>
-                {Math.ceil((new Date(item.reservedUntil) - now) / 60000)} хв
-              </Text>
-              {!pending && (
-                <AppButton
-                  title="Відмінити резерв"
-                  onPress={() => cancelReserve(item.id)}
-                  style={{ marginTop: 4 }}
-                />
+              {reserved && (
+                <>
+                  <Text style={styles.timerText}>
+                    {Math.ceil((new Date(item.reservedUntil) - now) / 60000)} хв
+                  </Text>
+                  {!pending && (
+                    <AppButton
+                      title="Відмінити резерв"
+                      onPress={() => cancelReserve(item.id)}
+                      style={{ marginTop: 4 }}
+                    />
+                  )}
+                </>
               )}
-              {role === 'CUSTOMER' && pending && item.candidateDriver && (
+            </View>
+          )}
+          {role === 'CUSTOMER' && (item.driver || item.reservedDriver || item.candidateDriver) && (
+            <View style={styles.driverBlock}>
+              <View style={styles.driverRow}>
+                <Ionicons name="person-circle" size={36} color={colors.green} />
+                <View style={{ marginLeft: 8, flex: 1 }}>
+                  <Text>{(item.driver || item.reservedDriver || item.candidateDriver).name}</Text>
+                  {(item.driver || item.reservedDriver || item.candidateDriver).rating && (
+                    <Text>Рейтинг: {(item.driver || item.reservedDriver || item.candidateDriver).rating.toFixed(1)}</Text>
+                  )}
+                </View>
+                {(item.driver || item.reservedDriver || item.candidateDriver).phone && (
+                  <TouchableOpacity onPress={() => Linking.openURL(`tel:${(item.driver || item.reservedDriver || item.candidateDriver).phone}`)}>
+                    <Ionicons name="call" size={28} color={colors.green} />
+                  </TouchableOpacity>
+                )}
+              </View>
+              {reserved && (
+                <Text style={styles.timerText}>
+                  {Math.ceil((new Date(item.reservedUntil) - now) / 60000)} хв
+                </Text>
+              )}
+              {pending && item.candidateDriver && (
                 <View style={styles.pendingRow}>
                   <AppButton
                     title="Підтвердити"

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -93,7 +93,7 @@ export default function OrderDetailScreen({ route, navigation }) {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` }
       });
-      navigation.navigate('Orders', { token });
+      navigation.navigate('Main', { screen: 'MyOrders' });
     } catch (err) {
       console.log(err);
     }
@@ -295,6 +295,24 @@ export default function OrderDetailScreen({ route, navigation }) {
         </Modal>
       )}
       </View>
+      {role === 'CUSTOMER' && (order.driver || order.reservedDriver || order.candidateDriver) && (
+        <View style={styles.driverBlock}>
+          <View style={styles.driverRow}>
+            <Ionicons name="person-circle" size={36} color={colors.green} />
+            <View style={{ marginLeft: 8, flex: 1 }}>
+              <Text>{(order.driver || order.reservedDriver || order.candidateDriver).name}</Text>
+              {(order.driver || order.reservedDriver || order.candidateDriver).rating && (
+                <Text>Рейтинг: {(order.driver || order.reservedDriver || order.candidateDriver).rating.toFixed(1)}</Text>
+              )}
+            </View>
+            {(order.driver || order.reservedDriver || order.candidateDriver).phone && (
+              <TouchableOpacity onPress={() => Linking.openURL(`tel:${(order.driver || order.reservedDriver || order.candidateDriver).phone}`)}>
+                <Ionicons name="call" size={28} color={colors.green} />
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      )}
       {role === 'DRIVER' && !order.driverId && (
         <View style={styles.bottomButtons}>
           {!reserved && <AppButton title="Резерв 10 хв" onPress={reserve} />}
@@ -355,6 +373,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 4,
   },
+  driverBlock: { marginBottom: 12 },
+  driverRow: { flexDirection: 'row', alignItems: 'center' },
   timer: { textAlign: 'right', fontSize: 16, color: colors.orange },
   fixedTimer: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- show driver name, rating and phone to customers on MyOrders
- display customer info to drivers regardless of reservation
- keep timer and actions only while reserve is active
- navigate back to the MyOrders tab after accepting an order

## Testing
- `npm -v`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bc849c7fc8324bc47cc9ddbfba923