### PR TITLE
Handle orphan favorites before syncing DB

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,21 @@ function scheduleCleanup() {
   }, next - now);
 }
 
+async function removeInvalidFavorites() {
+  try {
+    await db.query(`
+      DELETE FROM "favorites"
+      WHERE "customerId" NOT IN (SELECT id FROM "users")
+         OR "driverId" NOT IN (SELECT id FROM "users");
+    `);
+  } catch (e) {
+    // Ignore errors if table doesn't exist
+  }
+}
+
 async function start() {
   try {
+    await removeInvalidFavorites();
     await db.sync({ alter: true });
     const server = http.createServer(app);
     setupWebSocket(server);


### PR DESCRIPTION
## Summary
- clean up orphaned favorites referencing missing users
- run database sync after cleanup step

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: cannot read env DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685bee75a6ac83248ef540afed0363ea