### PR TITLE
Add status history timeline

### DIFF
--- a/mobile-app/src/components/StatusTimeline.js
+++ b/mobile-app/src/components/StatusTimeline.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from './Colors';
+
+export default function StatusTimeline({ history }) {
+  if (!history || history.length === 0) return null;
+  return (
+    <View style={styles.card}>
+      {history.map((h, i) => {
+        const isFirst = i === 0;
+        const isLast = i === history.length - 1;
+        const dotColor = isFirst ? colors.orange : isLast ? colors.green : '#ccc';
+        const lineColor = isLast ? colors.green : '#ccc';
+        return (
+          <View key={i} style={styles.row}>
+            <View style={styles.timeline}>
+              <View style={[styles.dot, { backgroundColor: dotColor }]} />
+              {!isLast && <View style={[styles.line, { backgroundColor: lineColor }]} />}
+            </View>
+            <View style={styles.content}>
+              <Text style={styles.time}>{new Date(h.at).toLocaleString()}</Text>
+              <Text style={styles.label}>{h.label || h.status}</Text>
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  row: { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 16 },
+  timeline: { width: 16, alignItems: 'center' },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  line: { flex: 1, width: 2, marginTop: 2 },
+  content: { flex: 1 },
+  label: { fontWeight: 'bold' },
+  time: { color: '#555', fontSize: 12 },
+});

--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -17,6 +17,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { apiFetch, HOST_URL } from '../api';
 import { colors } from '../components/Colors';
 import { useAuth } from '../AuthContext';
+import StatusTimeline from '../components/StatusTimeline';
 
 const statusLabels = {
   CREATED: 'Створено',
@@ -41,7 +42,8 @@ function formatDate(dateStr) {
 }
 
 export default function OrderDetailScreen({ route, navigation }) {
-  const { order } = route.params;
+  const { order: initialOrder } = route.params;
+  const [order, setOrder] = useState(initialOrder);
   const [previewIndex, setPreviewIndex] = useState(null);
   const { token, role } = useAuth();
   const [phone, setPhone] = useState(null);
@@ -197,7 +199,7 @@ export default function OrderDetailScreen({ route, navigation }) {
         headers: { Authorization: `Bearer ${token}` },
         body: JSON.stringify({ status }),
       });
-      Object.assign(order, updated);
+      setOrder(updated);
     } catch (err) {
       console.log(err);
     }
@@ -267,30 +269,12 @@ export default function OrderDetailScreen({ route, navigation }) {
         </View>
       )}
       {order.history && order.history.length > 0 && (
-        <View style={styles.historyCard}>
-          {order.history.map((h, i) => {
-            const isFirst = i === 0;
-            const isLast = i === order.history.length - 1;
-            const dotColor = isFirst
-              ? colors.orange
-              : isLast
-              ? colors.green
-              : '#ccc';
-            const lineColor = isLast ? colors.green : '#ccc';
-            return (
-              <View key={i} style={styles.historyRow}>
-                <View style={styles.timeline}>
-                  <View style={[styles.historyDot, { backgroundColor: dotColor }]} />
-                  {!isLast && <View style={[styles.historyLine, { backgroundColor: lineColor }]} />}
-                </View>
-                <View style={styles.historyContent}>
-                  <Text style={styles.historyTime}>{new Date(h.at).toLocaleString()}</Text>
-                  <Text style={styles.historyLabel}>{statusLabels[h.status] || h.status}</Text>
-                </View>
-              </View>
-            );
-          })}
-        </View>
+        <StatusTimeline
+          history={order.history.map((h) => ({
+            ...h,
+            label: statusLabels[h.status] || h.status,
+          }))}
+        />
       )}
       <View style={styles.detailsCard}>
       <View style={styles.row}>
@@ -463,24 +447,6 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   driverRow: { flexDirection: 'row', alignItems: 'center' },
-  historyCard: {
-    backgroundColor: '#fff',
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.05,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  historyRow: { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 16 },
-  timeline: { width: 16, alignItems: 'center' },
-  historyDot: { width: 8, height: 8, borderRadius: 4 },
-  historyLine: { flex: 1, width: 2, marginTop: 2 },
-  historyContent: { flex: 1 },
-  historyLabel: { fontWeight: 'bold' },
-  historyTime: { color: '#555', fontSize: 12 },
   timer: { textAlign: 'right', fontSize: 16, color: colors.orange },
   fixedTimer: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- show status history on order page with new `StatusTimeline` component
- keep order details updated after marking status so buttons update

## Testing
- `npm test` *(fails: Missing script)*
- `(cd mobile-app && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bfbce35048324ad2236eddc32c362