### PR TITLE
Fix order timeline data load

### DIFF
--- a/mobile-app/src/screens/OrderDetailScreen.js
+++ b/mobile-app/src/screens/OrderDetailScreen.js
@@ -52,6 +52,22 @@ export default function OrderDetailScreen({ route, navigation }) {
   const [reservedUntil, setReservedUntil] = useState(null);
   const [timeLeft, setTimeLeft] = useState(null);
 
+  useEffect(() => {
+    async function fetchOrder() {
+      try {
+        const data = await apiFetch(`/orders/${initialOrder.id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setOrder(data);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    fetchOrder();
+    const sub = navigation.addListener('focus', fetchOrder);
+    return sub;
+  }, [initialOrder.id, navigation, token]);
+
 
   useEffect(() => {
     if (order.reservedBy && order.reservedUntil) {

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -186,6 +186,26 @@ async function listMyOrders(req, res) {
   res.json(orders);
 }
 
+async function getOrder(req, res) {
+  const id = req.params.id;
+  try {
+    const order = await Order.findByPk(id, {
+      include: [
+        { model: require('../models/user'), as: 'driver' },
+        { model: require('../models/user'), as: 'candidateDriver' },
+        { model: require('../models/user'), as: 'reservedDriver' },
+        { model: require('../models/user'), as: 'customer' },
+      ],
+    });
+    if (!order) {
+      return res.status(404).send('Замовлення не знайдено');
+    }
+    res.json(order);
+  } catch (err) {
+    res.status(400).send('Не вдалося отримати замовлення');
+  }
+}
+
 async function reserveOrder(req, res) {
   const orderId = req.params.id;
   try {
@@ -458,6 +478,7 @@ module.exports = {
   rejectDriver,
   updateStatus,
   listMyOrders,
+  getOrder,
   updateOrder,
   deleteOrder,
 };

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -11,6 +11,7 @@ const {
   rejectDriver,
   updateStatus,
   listMyOrders,
+  getOrder,
   updateOrder,
   deleteOrder,
 } = require('../controllers/orderController');
@@ -23,6 +24,7 @@ router.get('/', authenticate, authorize([UserRole.DRIVER]), listAvailableOrders)
 router.post('/:id/reserve', authenticate, authorize([UserRole.DRIVER]), reserveOrder);
 router.post('/:id/cancel-reserve', authenticate, authorize([UserRole.DRIVER, UserRole.CUSTOMER]), cancelReserve);
 router.get('/my', authenticate, listMyOrders);
+router.get('/:id', authenticate, getOrder);
 router.post('/:id/accept', authenticate, authorize([UserRole.DRIVER]), acceptOrder);
 router.post('/:id/confirm-driver', authenticate, authorize([UserRole.CUSTOMER]), confirmDriver);
 router.post('/:id/reject-driver', authenticate, authorize([UserRole.CUSTOMER]), rejectDriver);


### PR DESCRIPTION
## Summary
- add order detail API route to ensure history data is available
- export and register getOrder in routes
- load order details on screen focus in React Native app

## Testing
- `node --check src/controllers/orderController.js`
- `node --check src/routes/orderRoutes.js`
- `node --check mobile-app/src/screens/OrderDetailScreen.js`


------
https://chatgpt.com/codex/tasks/task_e_685bff89c1e48324ae12a58ba3cdf198