### PR TITLE
Adjust cleanup to remove orders before today

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,10 @@ const PORT = process.env.PORT || 3000;
 function scheduleCleanup() {
   async function cleanup() {
     const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - 1);
-    await Order.destroy({ where: { loadFrom: { [Op.lte]: cutoff } } });
+    // Set to the start of the current day
+    cutoff.setHours(0, 0, 0, 0);
+    // Delete orders where load date is before today
+    await Order.destroy({ where: { loadFrom: { [Op.lt]: cutoff } } });
   }
   const now = new Date();
   const next = new Date(now);


### PR DESCRIPTION
## Summary
- refine `scheduleCleanup` logic to delete orders with `loadFrom` before the current day

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685cf7e5d9588324a54fa38ec8b8c1fb