### PR TITLE
Implement driver rejection status and improve order details

### DIFF
--- a/mobile-app/src/screens/MyOrdersScreen.js
+++ b/mobile-app/src/screens/MyOrdersScreen.js
@@ -15,6 +15,7 @@ const statusLabels = {
   COMPLETED: 'Виконано',
   PENDING: 'Очікує підтвердження',
   CANCELLED: 'Скасовано',
+  REJECTED: 'Відмовлено',
 };
 
 export default function MyOrdersScreen({ navigation }) {

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -1,4 +1,5 @@
 const Order = require('../models/order');
+const { OrderStatus } = require('../models/order');
 const Transaction = require('../models/transaction');
 const User = require('../models/user');
 const { SERVICE_FEE_PERCENT } = require('../config');
@@ -324,8 +325,12 @@ async function rejectDriver(req, res) {
     order.candidateUntil = null;
     order.reservedBy = null;
     order.reservedUntil = null;
-    order.status = 'CREATED';
-    order.history = [...(order.history || []), { status: 'CREATED', at: new Date() }];
+    order.status = OrderStatus.CREATED;
+    order.history = [
+      ...(order.history || []),
+      { status: OrderStatus.REJECTED, at: new Date() },
+      { status: OrderStatus.CREATED, at: new Date() },
+    ];
     await order.save();
     const updated = await Order.findByPk(orderId, {
       include: { model: require('../models/user'), as: 'customer' },

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -10,6 +10,7 @@ const OrderStatus = {
   COMPLETED: 'COMPLETED',
   PENDING: 'PENDING',
   CANCELLED: 'CANCELLED',
+  REJECTED: 'REJECTED',
 };
 
 class Order extends Model {}


### PR DESCRIPTION
## Summary
- add `REJECTED` to order statuses and record rejection in order history
- expose new status label in mobile app screens
- show contact info before order info for drivers
- display volume (m³) in order details

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cfc7ceb0083249f3c22b2c557cc8b