### PR TITLE
Add address search to order filters

### DIFF
--- a/mobile-app/src/components/AddressSearchInput.js
+++ b/mobile-app/src/components/AddressSearchInput.js
@@ -1,0 +1,131 @@
+import React, { useState, useRef } from 'react';
+import { View, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import AppInput from './AppInput';
+import AppText from './AppText';
+import { colors } from './Colors';
+
+export default function AddressSearchInput({
+  value,
+  onChangeText,
+  onSelect,
+  placeholder,
+  navigation,
+  onOpenMap,
+  lat,
+  lon,
+  style,
+}) {
+  const [suggestions, setSuggestions] = useState([]);
+  const timer = useRef(null);
+
+  async function loadSuggestions(text) {
+    if (text.length < 3) {
+      setSuggestions([]);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
+          text
+        )}&format=json&limit=5&countrycodes=ua&addressdetails=1`,
+        { headers: { 'User-Agent': 'vango-app' } }
+      );
+      const data = await res.json();
+      setSuggestions(data);
+    } catch {}
+  }
+
+  function handleChange(text) {
+    onChangeText(text);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => loadSuggestions(text), 1000);
+  }
+
+  function handleSelect(item) {
+    const addr = item.address || {};
+    const point = {
+      text: item.display_name,
+      lat: parseFloat(item.lat),
+      lon: parseFloat(item.lon),
+      city: addr.city || addr.town || addr.village || addr.state || '',
+      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
+      country: addr.country || '',
+      postcode: addr.postcode || '',
+    };
+    onSelect(point);
+    onChangeText(item.display_name);
+    setSuggestions([]);
+  }
+
+  return (
+    <View style={{ position: 'relative', zIndex: 10 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <AppInput
+          placeholder={placeholder}
+          value={value}
+          onChangeText={handleChange}
+          style={[style, { flex: 1 }]}
+        />
+        {navigation && (
+          <TouchableOpacity
+            style={styles.mapBtn}
+            onPress={() => {
+              if (onOpenMap) onOpenMap();
+              navigation.navigate('MapSelect', {
+                address: value,
+                lat,
+                lon,
+                onSelect: (p) => {
+                  onSelect(p);
+                  onChangeText(p.text || value);
+                },
+              });
+            }}
+          >
+            <Ionicons name="map" size={24} color={colors.green} />
+          </TouchableOpacity>
+        )}
+      </View>
+      {suggestions.length > 0 && (
+        <View style={[styles.suggestionsDropdown, styles.suggestionsBox]}>
+          <ScrollView keyboardShouldPersistTaps="handled">
+            {suggestions.map((item) => (
+              <TouchableOpacity
+                key={item.place_id}
+                style={styles.suggestionItem}
+                onPress={() => handleSelect(item)}
+              >
+                <AppText style={styles.suggestionMain}>{item.display_name}</AppText>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  suggestionsBox: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    maxHeight: 200,
+    overflow: 'hidden',
+  },
+  suggestionItem: {
+    padding: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  suggestionMain: { fontSize: 16 },
+  suggestionsDropdown: {
+    position: 'absolute',
+    top: 50,
+    left: 0,
+    right: 0,
+    zIndex: 100,
+    elevation: 5,
+  },
+  mapBtn: { marginLeft: 8 },
+});

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -5,6 +5,7 @@ import * as Location from 'expo-location';
 import { useAuth } from '../AuthContext';
 import { apiFetch, HOST_URL } from '../api';
 import AppInput from '../components/AppInput';
+import AddressSearchInput from '../components/AddressSearchInput';
 import AppButton from '../components/AppButton';
 import DateInput from '../components/DateInput';
 import OrderCard from '../components/OrderCard';
@@ -15,7 +16,9 @@ export default function AllOrdersScreen({ navigation }) {
 
   const [date, setDate] = useState(new Date());
   const [pickupCity, setPickupCity] = useState('');
+  const [pickupPoint, setPickupPoint] = useState(null);
   const [dropoffCity, setDropoffCity] = useState('');
+  const [dropoffPoint, setDropoffPoint] = useState(null);
   const [volume, setVolume] = useState('');
   const [weight, setWeight] = useState('');
   const [orders, setOrders] = useState([]);
@@ -44,6 +47,7 @@ export default function AllOrdersScreen({ navigation }) {
           const addr = data.address || {};
           const city = addr.city || addr.town || addr.village || addr.state || '';
           setPickupCity(city);
+          setPickupPoint(null);
           if (city) await AsyncStorage.setItem('pickupCity', city);
         }
       } catch {}
@@ -54,7 +58,10 @@ export default function AllOrdersScreen({ navigation }) {
       try {
         const storedCity = await AsyncStorage.getItem('pickupCity');
         const locStr = await AsyncStorage.getItem('location');
-        if (storedCity) setPickupCity(storedCity);
+        if (storedCity) {
+          setPickupCity(storedCity);
+          setPickupPoint(null);
+        }
         if (locStr) setLocation(JSON.parse(locStr));
         if (storedCity || locStr) {
           setDetected(true);
@@ -80,15 +87,15 @@ export default function AllOrdersScreen({ navigation }) {
     return () => {
       if (wsRef.current) wsRef.current.close();
     };
-  }, [detected, token, location]);
+  }, [detected, token, location, pickupPoint]);
 
   async function fetchOrders() {
     try {
       setLoading(true);
       const params = new URLSearchParams();
       if (date) params.append('date', formatDate(date));
-      if (pickupCity) params.append('pickupCity', pickupCity);
-      if (dropoffCity) params.append('dropoffCity', dropoffCity);
+      if (pickupCity) params.append('pickupCity', pickupPoint?.city || pickupCity);
+      if (dropoffCity) params.append('dropoffCity', dropoffPoint?.city || dropoffCity);
       if (volume) params.append('minVolume', volume);
       if (weight) params.append('minWeight', weight);
       const query = params.toString();
@@ -96,12 +103,13 @@ export default function AllOrdersScreen({ navigation }) {
         headers: { Authorization: `Bearer ${token}` },
       });
       let list = data.available;
-      if (radius && location) {
+      const origin = pickupPoint ? { latitude: parseFloat(pickupPoint.lat), longitude: parseFloat(pickupPoint.lon) } : location;
+      if (radius && origin) {
         const r = parseFloat(radius);
         if (!isNaN(r) && r > 0) {
           list = list.filter((o) => {
             if (!o.pickupLat || !o.pickupLon) return false;
-            const dist = haversine(location.latitude, location.longitude, o.pickupLat, o.pickupLon);
+            const dist = haversine(origin.latitude, origin.longitude, o.pickupLat, o.pickupLon);
             return dist <= r;
           });
         }
@@ -124,11 +132,12 @@ export default function AllOrdersScreen({ navigation }) {
     if (dropoffCity && !(o.dropoffCity || '').toLowerCase().includes(dropoffCity.toLowerCase())) return false;
     if (volume && parseFloat(o.volume || 0) < parseFloat(volume)) return false;
     if (weight && parseFloat(o.weight || 0) < parseFloat(weight)) return false;
-    if (radius && location) {
+    const origin = pickupPoint ? { latitude: parseFloat(pickupPoint.lat), longitude: parseFloat(pickupPoint.lon) } : location;
+    if (radius && origin) {
       const r = parseFloat(radius);
       if (!isNaN(r) && r > 0) {
         if (!o.pickupLat || !o.pickupLon) return false;
-        const dist = haversine(location.latitude, location.longitude, o.pickupLat, o.pickupLon);
+        const dist = haversine(origin.latitude, origin.longitude, o.pickupLat, o.pickupLon);
         if (dist > r) return false;
       }
     }
@@ -140,8 +149,8 @@ export default function AllOrdersScreen({ navigation }) {
     if (wsRef.current) wsRef.current.close();
     const params = new URLSearchParams();
     if (date) params.append('date', formatDate(date));
-    if (pickupCity) params.append('pickupCity', pickupCity);
-    if (dropoffCity) params.append('dropoffCity', dropoffCity);
+    if (pickupCity) params.append('pickupCity', pickupPoint?.city || pickupCity);
+    if (dropoffCity) params.append('dropoffCity', dropoffPoint?.city || dropoffCity);
     if (volume) params.append('minVolume', volume);
     if (weight) params.append('minWeight', weight);
     const url = `${HOST_URL.replace(/^http/, 'ws')}/api/orders/stream?${params}`;
@@ -177,7 +186,9 @@ export default function AllOrdersScreen({ navigation }) {
   function clearFilters() {
     setDate(new Date());
     setPickupCity('');
+    setPickupPoint(null);
     setDropoffCity('');
+    setDropoffPoint(null);
     setVolume('');
     setWeight('');
     setRadius('30');
@@ -215,16 +226,32 @@ export default function AllOrdersScreen({ navigation }) {
         <SafeAreaView style={styles.modalContainer}>
           <ScrollView contentContainerStyle={styles.filters}>
           <DateInput value={date} onChange={setDate} style={styles.input} />
-          <AppInput
-            placeholder="Місто завантаження"
+          <AddressSearchInput
+            placeholder="Місце завантаження"
             value={pickupCity}
-            onChangeText={setPickupCity}
+            onChangeText={(t) => {
+              setPickupCity(t);
+              if (!t) setPickupPoint(null);
+            }}
+            onSelect={setPickupPoint}
+            navigation={navigation}
+            onOpenMap={() => setFiltersVisible(false)}
+            lat={pickupPoint?.lat}
+            lon={pickupPoint?.lon}
             style={styles.input}
           />
-          <AppInput
-            placeholder="Місто розвантаження"
+          <AddressSearchInput
+            placeholder="Місце розвантаження"
             value={dropoffCity}
-            onChangeText={setDropoffCity}
+            onChangeText={(t) => {
+              setDropoffCity(t);
+              if (!t) setDropoffPoint(null);
+            }}
+            onSelect={setDropoffPoint}
+            navigation={navigation}
+            onOpenMap={() => setFiltersVisible(false)}
+            lat={dropoffPoint?.lat}
+            lon={dropoffPoint?.lon}
             style={styles.input}
           />
           <AppInput


### PR DESCRIPTION
## Summary
- add reusable `AddressSearchInput` component with suggestions and map selector
- enhance `AllOrdersScreen` filters to use address search inputs
- compute radius from selected pickup point when available
- fix map visibility when opened from filters

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686036cf2a588324970b9e6e3d8c6782