### PR TITLE
Add reopening filter after map selection

### DIFF
--- a/mobile-app/src/components/AddressSearchInput.js
+++ b/mobile-app/src/components/AddressSearchInput.js
@@ -1,0 +1,137 @@
+import React, { useState, useRef } from 'react';
+import { View, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import AppInput from './AppInput';
+import AppText from './AppText';
+import { colors } from './Colors';
+
+export default function AddressSearchInput({
+  value,
+  onChangeText,
+  onSelect,
+  placeholder,
+  navigation,
+  onOpenMap,
+  onCloseMap,
+  lat,
+  lon,
+  currentLocation,
+  style,
+}) {
+  const [suggestions, setSuggestions] = useState([]);
+  const timer = useRef(null);
+
+  async function loadSuggestions(text) {
+    if (text.length < 3) {
+      setSuggestions([]);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
+          text
+        )}&format=json&limit=5&countrycodes=ua&addressdetails=1`,
+        { headers: { 'User-Agent': 'vango-app' } }
+      );
+      const data = await res.json();
+      setSuggestions(data);
+    } catch {}
+  }
+
+  function handleChange(text) {
+    onChangeText(text);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => loadSuggestions(text), 1000);
+  }
+
+  function handleSelect(item) {
+    const addr = item.address || {};
+    const point = {
+      text: item.display_name,
+      lat: parseFloat(item.lat),
+      lon: parseFloat(item.lon),
+      city: addr.city || addr.town || addr.village || addr.state || '',
+      address: [addr.road, addr.house_number].filter(Boolean).join(' '),
+      country: addr.country || '',
+      postcode: addr.postcode || '',
+    };
+    onSelect(point);
+    onChangeText(item.display_name);
+    setSuggestions([]);
+  }
+
+  return (
+    <View style={{ position: 'relative', zIndex: 10 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <AppInput
+          placeholder={placeholder}
+          value={value}
+          onChangeText={handleChange}
+          style={[style, { flex: 1 }]}
+        />
+        {navigation && (
+          <TouchableOpacity
+            style={styles.mapBtn}
+            onPress={() => {
+              if (onOpenMap) onOpenMap();
+              navigation.navigate('MapSelect', {
+                address: value,
+                lat,
+                lon,
+                userLat: currentLocation?.latitude,
+                userLon: currentLocation?.longitude,
+                onSelect: (p) => {
+                  onSelect(p);
+                  onChangeText(p.text || value);
+                },
+                onClose: onCloseMap,
+              });
+            }}
+          >
+            <Ionicons name="map" size={24} color={colors.green} />
+          </TouchableOpacity>
+        )}
+      </View>
+      {suggestions.length > 0 && (
+        <View style={[styles.suggestionsDropdown, styles.suggestionsBox]}>
+          <ScrollView keyboardShouldPersistTaps="handled">
+            {suggestions.map((item) => (
+              <TouchableOpacity
+                key={item.place_id}
+                style={styles.suggestionItem}
+                onPress={() => handleSelect(item)}
+              >
+                <AppText style={styles.suggestionMain}>{item.display_name}</AppText>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  suggestionsBox: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    maxHeight: 200,
+    overflow: 'hidden',
+  },
+  suggestionItem: {
+    padding: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  suggestionMain: { fontSize: 16 },
+  suggestionsDropdown: {
+    position: 'absolute',
+    top: 50,
+    left: 0,
+    right: 0,
+    backgroundColor: '#fff',
+    zIndex: 100,
+    elevation: 5,
+  },
+  mapBtn: { marginLeft: 8 },
+});

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -477,6 +477,7 @@ const styles = StyleSheet.create({
     top: 50,
     left: 0,
     right: 0,
+    backgroundColor: '#fff',
     zIndex: 100,
     elevation: 5,
   },

--- a/mobile-app/src/screens/EditOrderScreen.js
+++ b/mobile-app/src/screens/EditOrderScreen.js
@@ -487,6 +487,7 @@ const styles = StyleSheet.create({
     top: 50,
     left: 0,
     right: 0,
+    backgroundColor: '#fff',
     zIndex: 100,
     elevation: 5,
   },

--- a/mobile-app/src/screens/MapSelectScreen.js
+++ b/mobile-app/src/screens/MapSelectScreen.js
@@ -5,10 +5,10 @@ import { Ionicons } from '@expo/vector-icons';
 import AppButton from '../components/AppButton';
 
 export default function MapSelectScreen({ navigation, route }) {
-  const { onSelect, address, lat, lon } = route.params || {};
+  const { onSelect, address, lat, lon, onClose, userLat, userLon } = route.params || {};
   const [region, setRegion] = useState({
-    latitude: lat ? parseFloat(lat) : 50.4501,
-    longitude: lon ? parseFloat(lon) : 30.5234,
+    latitude: lat ? parseFloat(lat) : userLat ? parseFloat(userLat) : 50.4501,
+    longitude: lon ? parseFloat(lon) : userLon ? parseFloat(userLon) : 30.5234,
     latitudeDelta: 0.05,
     longitudeDelta: 0.05,
   });
@@ -34,6 +34,13 @@ export default function MapSelectScreen({ navigation, route }) {
     }
     geocode();
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      if (onClose) onClose();
+    });
+    return unsubscribe;
+  }, [navigation, onClose]);
 
   async function confirm() {
     if (onSelect && marker) {


### PR DESCRIPTION
## Summary
- keep filters visible after closing the map selector
- propagate a new `onCloseMap` callback through `AddressSearchInput`
- call `onCloseMap` when navigating away from `MapSelectScreen`
- zoom to the user's location when opening the pickup map
- fill the background of address dropdowns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686036cf2a588324970b9e6e3d8c6782