### PR TITLE
Redesign menu and settings

### DIFF
--- a/mobile-app/src/components/Colors.js
+++ b/mobile-app/src/components/Colors.js
@@ -1,6 +1,10 @@
 export const colors = {
-  green: '#6abf69',
-  orange: '#ffb74d',
-  text: '#333',
-  border: '#ccc'
+  primary: '#16a34a',
+  green: '#16a34a',
+  orange: '#f97316',
+  text: '#273033',
+  textSecondary: '#4b5563',
+  background: '#f9fafb',
+  border: '#e5e7eb',
+  press: '#e7f6ec',
 };

--- a/mobile-app/src/components/ListItem.js
+++ b/mobile-app/src/components/ListItem.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from './Colors';
+
+export default function ListItem({ title, onPress, children, style }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.container,
+        pressed && styles.pressed,
+        style,
+      ]}
+    >
+      <Text style={styles.title}>{title}</Text>
+      <View style={styles.content}>{children}</View>
+      {onPress && (
+        <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  pressed: {
+    backgroundColor: colors.press,
+  },
+  title: {
+    fontSize: 16,
+    color: colors.text,
+    flex: 1,
+  },
+  content: {
+    marginRight: 8,
+  },
+});

--- a/mobile-app/src/screens/MainTabs.js
+++ b/mobile-app/src/screens/MainTabs.js
@@ -24,7 +24,11 @@ export default function MainTabs() {
           if (route.name === 'Settings') name = 'settings';
           return <Ionicons name={name} size={size} color={color} />;
         },
-        tabBarActiveTintColor: colors.green,
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
+        tabBarStyle: { backgroundColor: colors.background },
+        headerStyle: { backgroundColor: colors.background },
+        headerTitleStyle: { color: colors.text },
       })}
     >
       {role === 'CUSTOMER' ? (

--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -1,11 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import AppButton from '../components/AppButton';
 import { useAuth } from '../AuthContext';
 import RoleSwitch from '../components/RoleSwitch';
+import AppText from '../components/AppText';
+import { apiFetch } from '../api';
+import ListItem from '../components/ListItem';
+import { colors } from '../components/Colors';
 
 export default function SettingsScreen() {
-  const { logout, role, selectRole } = useAuth();
+  const { logout, role, selectRole, token } = useAuth();
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      try {
+        const me = await apiFetch('/auth/me', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setUser(me);
+      } catch {}
+    }
+    load();
+  }, [token]);
 
   function handleChange(r) {
     if (r !== role) selectRole(r);
@@ -13,14 +31,58 @@ export default function SettingsScreen() {
 
   return (
     <View style={styles.container}>
-      <RoleSwitch value={role} onChange={handleChange} style={styles.switch} />
-      <AppButton title="Вийти" onPress={logout} />
+      {user && (
+        <View style={styles.userInfo}>
+          <AppText style={styles.name}>{user.name}</AppText>
+          <AppText style={styles.phone}>{user.phone}</AppText>
+        </View>
+      )}
+      <AppText style={styles.subtitle}>
+        Дозвольте мені більше про вас дізнатись.
+      </AppText>
+      <View style={styles.list}>
+        <ListItem title="Профіль користувача" onPress={() => {}} />
+        <ListItem title="Мова" onPress={() => {}} />
+        <ListItem title="Тема">
+          <RoleSwitch value={role} onChange={handleChange} />
+        </ListItem>
+      </View>
+      <AppButton title="Вийти" onPress={logout} style={styles.logout} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
-  switch: { marginBottom: 24 },
-
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 24,
+  },
+  userInfo: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+  },
+  phone: {
+    color: colors.textSecondary,
+    marginTop: 4,
+  },
+  subtitle: {
+    color: colors.textSecondary,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  list: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    overflow: 'hidden',
+    marginBottom: 24,
+  },
+  logout: {
+    marginTop: 'auto',
+  },
 });


### PR DESCRIPTION
## Summary
- adjust app color palette
- style tab navigation to match new design
- display profile data in settings
- add basic list item component

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862688b7a6883248befad99b406e1f1