### PR TITLE
Fix time range inputs layout

### DIFF
--- a/mobile-app/src/components/DateInput.js
+++ b/mobile-app/src/components/DateInput.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity, Platform } from 'react-native';
+import { View, TouchableOpacity, Platform, StyleSheet } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import AppInput from './AppInput';
+import { Ionicons } from '@expo/vector-icons';
 
-export default function DateInput({ value, onChange, style }) {
+export default function DateInput({ value, onChange, style, placeholder }) {
 
   const [showDate, setShowDate] = useState(false);
 
@@ -18,12 +19,16 @@ export default function DateInput({ value, onChange, style }) {
   return (
     <View>
       <TouchableOpacity onPress={() => setShowDate(true)}>
-        <AppInput
-          value={formatDate(value)}
-          editable={false}
-          pointerEvents="none"
-          style={style}
-        />
+        <View>
+          <AppInput
+            value={formatDate(value)}
+            placeholder={placeholder}
+            editable={false}
+            pointerEvents="none"
+            style={[{ paddingRight: 36, marginVertical: 0 }, style]}
+          />
+          <Ionicons name="calendar-outline" size={16} color="#000" style={styles.icon} />
+        </View>
       </TouchableOpacity>
       {showDate && (
         <DateTimePicker
@@ -41,5 +46,9 @@ export default function DateInput({ value, onChange, style }) {
 function formatDate(d) {
   if (!d) return '';
   const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
 }
+
+const styles = StyleSheet.create({
+  icon: { position: 'absolute', right: 12, top: 20 },
+});

--- a/mobile-app/src/components/TimeInput.js
+++ b/mobile-app/src/components/TimeInput.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity, Platform } from 'react-native';
+import { View, TouchableOpacity, Platform, StyleSheet } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import AppInput from './AppInput';
+import { Ionicons } from '@expo/vector-icons';
 
-export default function TimeInput({ value, onChange, style }) {
+export default function TimeInput({ value, onChange, style, placeholder }) {
 
   const [showTime, setShowTime] = useState(false);
 
@@ -19,13 +20,16 @@ export default function TimeInput({ value, onChange, style }) {
   return (
     <View>
       <TouchableOpacity onPress={() => setShowTime(true)}>
-        <AppInput
-          value={formatTime(value)}
-          editable={false}
-          pointerEvents="none"
-          style={style}
-        />
-
+        <View>
+          <AppInput
+            value={formatTime(value)}
+            placeholder={placeholder}
+            editable={false}
+            pointerEvents="none"
+            style={[{ paddingRight: 36, marginVertical: 0 }, style]}
+          />
+          <Ionicons name="time-outline" size={16} color="#000" style={styles.icon} />
+        </View>
       </TouchableOpacity>
       {showTime && (
         <DateTimePicker
@@ -45,3 +49,7 @@ function formatTime(d) {
   const pad = (n) => (n < 10 ? `0${n}` : n);
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
+
+const styles = StyleSheet.create({
+  icon: { position: 'absolute', right: 12, top: 20 },
+});

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -362,45 +362,63 @@ export default function CreateOrderScreen({ navigation }) {
         <Ionicons name="arrow-down-circle" size={20} color={colors.green} />
         <AppText style={styles.label}>Завантаження</AppText>
       </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <DateInput
+      <DateInput
+        value={loadFrom}
+        onChange={(d) => {
+          const from = new Date(loadFrom);
+          from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          const to = new Date(loadTo);
+          to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          setLoadFrom(from);
+          setLoadTo(to);
+        }}
+        style={{ marginTop: 0, marginBottom: 12 }}
+        placeholder="DD.MM.YYYY"
+      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput
           value={loadFrom}
-          onChange={(d) => {
-            const from = new Date(loadFrom);
-            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            const to = new Date(loadTo);
-            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            setLoadFrom(from);
-            setLoadTo(to);
-          }}
-          style={{ marginVertical: 0 }}
+          onChange={setLoadFrom}
+          style={{ flex: 1 }}
+          placeholder="09:00"
         />
-        <View style={{ flexDirection: 'column' }}>
-          <TimeInput value={loadFrom} onChange={setLoadFrom} style={{ marginVertical: 0 }} />
-          <TimeInput value={loadTo} onChange={setLoadTo} style={{ marginVertical: 0 }} />
-        </View>
+        <TimeInput
+          value={loadTo}
+          onChange={setLoadTo}
+          style={{ flex: 1 }}
+          placeholder="18:00"
+        />
       </View>
       <View style={styles.section}>
         <Ionicons name="arrow-up-circle" size={20} color={colors.orange} />
         <AppText style={styles.label}>Вивантаження</AppText>
       </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <DateInput
+      <DateInput
+        value={unloadFrom}
+        onChange={(d) => {
+          const from = new Date(unloadFrom);
+          from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          const to = new Date(unloadTo);
+          to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          setUnloadFrom(from);
+          setUnloadTo(to);
+        }}
+        style={{ marginTop: 0, marginBottom: 12 }}
+        placeholder="DD.MM.YYYY"
+      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput
           value={unloadFrom}
-          onChange={(d) => {
-            const from = new Date(unloadFrom);
-            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            const to = new Date(unloadTo);
-            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            setUnloadFrom(from);
-            setUnloadTo(to);
-          }}
-          style={{ marginVertical: 0 }}
+          onChange={setUnloadFrom}
+          style={{ flex: 1 }}
+          placeholder="09:00"
         />
-      <View style={{ flexDirection: 'column' }}>
-        <TimeInput value={unloadFrom} onChange={setUnloadFrom} style={{ marginVertical: 0 }} />
-        <TimeInput value={unloadTo} onChange={setUnloadTo} style={{ marginVertical: 0 }} />
-      </View>
+        <TimeInput
+          value={unloadTo}
+          onChange={setUnloadTo}
+          style={{ flex: 1 }}
+          placeholder="18:00"
+        />
       </View>
 
       <View style={styles.section}>

--- a/mobile-app/src/screens/EditOrderScreen.js
+++ b/mobile-app/src/screens/EditOrderScreen.js
@@ -372,48 +372,64 @@ export default function EditOrderScreen({ route, navigation }) {
         <Ionicons name="arrow-down-circle" size={20} color={colors.green} />
         <AppText style={styles.label}>Завантаження</AppText>
       </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <DateInput
+      <DateInput
+        value={loadFrom}
+        onChange={(d) => {
+          const from = new Date(loadFrom);
+          from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          const to = new Date(loadTo);
+          to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          setLoadFrom(from);
+          setLoadTo(to);
+        }}
+        style={{ marginTop: 0, marginBottom: 12 }}
+        placeholder="DD.MM.YYYY"
+      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput
           value={loadFrom}
-          onChange={(d) => {
-            const from = new Date(loadFrom);
-            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            const to = new Date(loadTo);
-            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            setLoadFrom(from);
-            setLoadTo(to);
-          }}
-          style={{ marginVertical: 0 }}
+          onChange={setLoadFrom}
+          style={{ flex: 1 }}
+          placeholder="09:00"
         />
-        <View style={{ flexDirection: 'column' }}>
-          <TimeInput value={loadFrom} onChange={setLoadFrom} style={{ marginVertical: 0 }} />
-          <TimeInput value={loadTo} onChange={setLoadTo} style={{ marginVertical: 0 }} />
-        </View>
+        <TimeInput
+          value={loadTo}
+          onChange={setLoadTo}
+          style={{ flex: 1 }}
+          placeholder="18:00"
+        />
       </View>
 
       <View style={styles.section}>
         <Ionicons name="arrow-up-circle" size={20} color={colors.orange} />
         <AppText style={styles.label}>Вивантаження</AppText>
       </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-
-        <DateInput
+      <DateInput
+        value={unloadFrom}
+        onChange={(d) => {
+          const from = new Date(unloadFrom);
+          from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          const to = new Date(unloadTo);
+          to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
+          setUnloadFrom(from);
+          setUnloadTo(to);
+        }}
+        style={{ marginTop: 0, marginBottom: 12 }}
+        placeholder="DD.MM.YYYY"
+      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <TimeInput
           value={unloadFrom}
-          onChange={(d) => {
-            const from = new Date(unloadFrom);
-            from.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            const to = new Date(unloadTo);
-            to.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
-            setUnloadFrom(from);
-            setUnloadTo(to);
-          }}
-          style={{ marginVertical: 0 }}
+          onChange={setUnloadFrom}
+          style={{ flex: 1 }}
+          placeholder="09:00"
         />
-        <View style={{ flexDirection: 'column' }}>
-          <TimeInput value={unloadFrom} onChange={setUnloadFrom} style={{ marginVertical: 0 }} />
-          <TimeInput value={unloadTo} onChange={setUnloadTo} style={{ marginVertical: 0 }} />
-        </View>
-
+        <TimeInput
+          value={unloadTo}
+          onChange={setUnloadTo}
+          style={{ flex: 1 }}
+          placeholder="18:00"
+        />
       </View>
 
       <View style={styles.section}>


### PR DESCRIPTION
## Summary
- add calendar/clock icons in DateInput/TimeInput
- format date as DD.MM.YYYY
- layout date/time inputs vertically in order screens

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68639fead2548324983e6bbff5ebe145