### PR TITLE
Apply new design to order detail screen

### DIFF
--- a/mobile-app/src/components/AppButton.js
+++ b/mobile-app/src/components/AppButton.js
@@ -1,25 +1,55 @@
 import React from 'react';
-import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { Pressable, Text, StyleSheet } from 'react-native';
 import { colors } from './Colors';
 
-export default function AppButton({ title, color = colors.green, style, textStyle, ...props }) {
+export default function AppButton({
+  title,
+  variant = 'success',
+  color,
+  style,
+  textStyle,
+  disabled,
+  ...props
+}) {
+  const bgColor =
+    color ||
+    (variant === 'warning'
+      ? colors.orange
+      : variant === 'danger'
+      ? colors.red
+      : colors.green);
+
   return (
-    <TouchableOpacity style={[styles.button, { backgroundColor: color }, style]} {...props}>
+    <Pressable
+      style={({ pressed }) => [
+        styles.button,
+        {
+          backgroundColor: bgColor,
+          opacity: disabled ? 0.4 : 1,
+          transform: pressed ? [{ scale: 0.92 }] : undefined,
+        },
+        style,
+      ]}
+      disabled={disabled}
+      {...props}
+    >
       <Text style={[styles.text, textStyle]}>{title}</Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 8,
+    height: 56,
+    borderRadius: 12,
+    justifyContent: 'center',
     alignItems: 'center',
-    marginVertical: 8,
+    width: '100%',
+    marginVertical: 4,
   },
   text: {
     color: '#fff',
     fontSize: 16,
+    fontWeight: '600',
   },
 });

--- a/mobile-app/src/components/Colors.js
+++ b/mobile-app/src/components/Colors.js
@@ -1,7 +1,8 @@
 export const colors = {
   primary: '#16a34a',
   green: '#16a34a',
-  orange: '#f97316',
+  orange: '#EA580C',
+  red: '#EF4444',
   text: '#273033',
   textSecondary: '#4b5563',
   background: '#f9fafb',


### PR DESCRIPTION
## Summary
- update color palette with `red` and new orange tone
- enhance `AppButton` with variants and pressed feedback
- redesign OrderDetailScreen: new app bar, status card, and fixed action area

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863a220d9e88324b9dd66339ff40674