### PR TITLE
Fix keyboard dismiss and add role change skeleton

### DIFF
--- a/mobile-app/src/components/ProfileCardSkeleton.js
+++ b/mobile-app/src/components/ProfileCardSkeleton.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Skeleton from './Skeleton';
+import { colors } from './Colors';
+
+export default function ProfileCardSkeleton({ style }) {
+  return (
+    <View style={[styles.card, style]}>
+      <Skeleton style={styles.avatar} />
+      <Skeleton style={styles.line} />
+      <Skeleton style={[styles.line, { width: '60%' }]} />
+      <Skeleton style={styles.switch} />
+      <Skeleton style={styles.button} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  avatar: { width: 96, height: 96, borderRadius: 48 },
+  line: { height: 20, borderRadius: 4, width: '80%', marginTop: 16 },
+  switch: { height: 32, width: '100%', borderRadius: 20, marginTop: 24 },
+  button: { height: 48, width: '100%', borderRadius: 12, marginTop: 16 },
+});

--- a/mobile-app/src/screens/RegisterScreen.js
+++ b/mobile-app/src/screens/RegisterScreen.js
@@ -1,5 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Keyboard,
+  TouchableWithoutFeedback,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
 
 import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
@@ -52,10 +59,15 @@ export default function RegisterScreen({ navigation }) {
   }
 
   return (
-    <View style={styles.container}>
-      <AppText style={styles.label}>Ім'я</AppText>
-      <AppInput value={name} onChangeText={setName} placeholder="Ваше ім'я" />
-      <AppText style={styles.label}>Електронна пошта</AppText>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <View style={styles.container}>
+          <AppText style={styles.label}>Ім'я</AppText>
+          <AppInput value={name} onChangeText={setName} placeholder="Ваше ім'я" />
+          <AppText style={styles.label}>Електронна пошта</AppText>
       <AppInput
         value={email}
         onChangeText={setEmail}
@@ -72,9 +84,11 @@ export default function RegisterScreen({ navigation }) {
       <AppInput value={phone} onChangeText={setPhone} placeholder="380..." keyboardType="phone-pad" />
       <AppText style={styles.label}>Місто</AppText>
       <AppInput value={city} onChangeText={setCity} placeholder="Київ" />
-      {error && <AppText style={styles.error}>{error}</AppText>}
-      <AppButton title="Зареєструватися" onPress={handleRegister} />
-    </View>
+          {error && <AppText style={styles.error}>{error}</AppText>}
+          <AppButton title="Зареєструватися" onPress={handleRegister} />
+        </View>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -8,27 +8,41 @@ import AppText from '../components/AppText';
 import { apiFetch } from '../api';
 import ListItem from '../components/ListItem';
 import { colors } from '../components/Colors';
+import ProfileCardSkeleton from '../components/ProfileCardSkeleton';
 
 export default function SettingsScreen() {
   const { logout, role, selectRole, token } = useAuth();
   const [user, setUser] = useState(null);
+  const [loadingProfile, setLoadingProfile] = useState(true);
 
   useEffect(() => {
     async function load() {
       if (!token) return;
       try {
+        setLoadingProfile(true);
         const me = await apiFetch('/auth/me', {
           headers: { Authorization: `Bearer ${token}` },
         });
         setUser(me);
       } catch {}
+      finally {
+        setLoadingProfile(false);
+      }
     }
     load();
   }, [token]);
 
   async function handleChange(r) {
     if (r !== role) {
+      setLoadingProfile(true);
       await selectRole(r);
+      try {
+        const me = await apiFetch('/auth/me', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setUser(me);
+      } catch {}
+      setLoadingProfile(false);
     }
   }
 
@@ -40,11 +54,14 @@ export default function SettingsScreen() {
 
   return (
     <View style={styles.container}>
-      {user && (
-        <View style={styles.profileCard}>
-          <View style={styles.avatar}>
-            <AppText style={styles.avatarText}>{initials}</AppText>
-          </View>
+      {loadingProfile ? (
+        <ProfileCardSkeleton />
+      ) : (
+        user && (
+          <View style={styles.profileCard}>
+            <View style={styles.avatar}>
+              <AppText style={styles.avatarText}>{initials}</AppText>
+            </View>
           <AppText style={styles.name}>{user.name}</AppText>
           <AppText style={styles.phone}>{user.phone}</AppText>
 


### PR DESCRIPTION
## Summary
- dismiss keyboard on iOS registration screen by tapping outside
- add profile card skeleton and show it when changing role in settings

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686615cdb6f4832499538f87fed8ef9e