### PR TITLE
Sync map with order list and adjust sheet

### DIFF
--- a/mobile-app/src/components/BottomSheet.js
+++ b/mobile-app/src/components/BottomSheet.js
@@ -8,7 +8,8 @@ const BottomSheet = React.forwardRef(function BottomSheet({
   children,
   style,
 }, ref) {
-  const expandedOffset = SCREEN_HEIGHT * 0.1;
+  // Leave more space from the top when expanded
+  const expandedOffset = SCREEN_HEIGHT * 0.2;
   const collapsedOffset = SCREEN_HEIGHT - collapsedHeight;
 
   const [expanded, setExpanded] = useState(false);

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -34,6 +34,7 @@ export default function AllOrdersScreen({ navigation }) {
   const [detected, setDetected] = useState(false);
   const sheetRef = useRef(null);
   const listRef = useRef(null);
+  const mapRef = useRef(null);
 
   useEffect(() => {
     async function detectCity() {
@@ -222,6 +223,19 @@ export default function AllOrdersScreen({ navigation }) {
     sheetRef.current?.expand();
   }
 
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const coords = orders
+      .filter((o) => o.pickupLat && o.pickupLon)
+      .map((o) => ({ latitude: o.pickupLat, longitude: o.pickupLon }));
+    if (coords.length) {
+      mapRef.current.fitToCoordinates(coords, {
+        edgePadding: { top: 80, right: 80, bottom: 80, left: 80 },
+        animated: true,
+      });
+    }
+  }, [orders]);
+
 
   const region = location
     ? { latitude: location.latitude, longitude: location.longitude, latitudeDelta: 0.2, longitudeDelta: 0.2 }
@@ -229,7 +243,7 @@ export default function AllOrdersScreen({ navigation }) {
 
   return (
     <View style={{ flex: 1 }}>
-      <MapView style={{ flex: 1 }} initialRegion={region} showsUserLocation>
+      <MapView ref={mapRef} style={{ flex: 1 }} initialRegion={region} showsUserLocation>
         {location && (
           <Circle
             center={location}


### PR DESCRIPTION
## Summary
- increase empty space when the bottom sheet expands
- sync map view with the list of orders so all pickup markers are visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686623195d20832489a30b7c3b21741b