### PR TITLE
Improve city search dropdown

### DIFF
--- a/mobile-app/src/components/AddressSearchInput.js
+++ b/mobile-app/src/components/AddressSearchInput.js
@@ -34,7 +34,19 @@ export default function AddressSearchInput({
         { headers: { 'User-Agent': 'vango-app' } }
       );
       const data = await res.json();
-      setSuggestions(data);
+      const allowed = ['city', 'town', 'village', 'hamlet', 'locality'];
+      const used = new Set();
+      const unique = [];
+      for (const item of data) {
+        if (!allowed.includes(item.type)) continue;
+        const addr = item.address || {};
+        const cityName = addr.city || addr.town || addr.village || addr.state || '';
+        if (cityName && !used.has(cityName)) {
+          used.add(cityName);
+          unique.push(item);
+        }
+      }
+      setSuggestions(unique);
     } catch {}
   }
 
@@ -46,22 +58,23 @@ export default function AddressSearchInput({
 
   function handleSelect(item) {
     const addr = item.address || {};
+    const cityName = addr.city || addr.town || addr.village || addr.state || '';
     const point = {
       text: item.display_name,
       lat: parseFloat(item.lat),
       lon: parseFloat(item.lon),
-      city: addr.city || addr.town || addr.village || addr.state || '',
+      city: cityName,
       address: [addr.road, addr.house_number].filter(Boolean).join(' '),
       country: addr.country || '',
       postcode: addr.postcode || '',
     };
     onSelect(point);
-    onChangeText(item.display_name);
+    onChangeText(cityName);
     setSuggestions([]);
   }
 
   return (
-    <View style={{ position: 'relative', zIndex: 10 }}>
+    <View style={{ position: 'relative', zIndex: 100 }}>
       <View style={{ flexDirection: 'row', alignItems: 'center' }}>
         <AppInput
           placeholder={placeholder}
@@ -126,11 +139,11 @@ const styles = StyleSheet.create({
   suggestionMain: { fontSize: 16 },
   suggestionsDropdown: {
     position: 'absolute',
-    top: 50,
+    top: '100%',
     left: 0,
     right: 0,
     backgroundColor: '#fff',
-    zIndex: 100,
+    zIndex: 9999,
     elevation: 5,
   },
   mapBtn: { marginLeft: 8 },

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -256,16 +256,19 @@ export default function AllOrdersScreen({ navigation }) {
   }, [orders, radius, pickupPoint, location]);
 
 
-  const region = location
-    ? { latitude: location.latitude, longitude: location.longitude, latitudeDelta: 0.2, longitudeDelta: 0.2 }
+  const originPoint = pickupPoint
+    ? { latitude: parseFloat(pickupPoint.lat), longitude: parseFloat(pickupPoint.lon) }
+    : location;
+  const region = originPoint
+    ? { latitude: originPoint.latitude, longitude: originPoint.longitude, latitudeDelta: 0.2, longitudeDelta: 0.2 }
     : { latitude: 50.45, longitude: 30.523, latitudeDelta: 0.2, longitudeDelta: 0.2 };
 
   return (
     <View style={{ flex: 1 }}>
       <MapView ref={mapRef} style={{ flex: 1 }} initialRegion={region} showsUserLocation>
-        {location && (
+        {originPoint && (
           <Circle
-            center={location}
+            center={originPoint}
             radius={parseFloat(radius || '0') * 1000}
             fillColor="rgba(22,163,74,0.15)"
             strokeColor="rgba(22,163,74,0.4)"


### PR DESCRIPTION
## Summary
- filter suggestions by city but show full address info
- only keep city name in input after selection
- position dropdown right below input
- draw radius around selected pickup city

## Testing
- `npm test` *(fails: Missing script: "test")*
- `(cd mobile-app && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68662a9c8d5c83249cbe6cc754764eb7