### PR TITLE
Fix dropdown overlay issue

### DIFF
--- a/mobile-app/src/components/AddressSearchInput.js
+++ b/mobile-app/src/components/AddressSearchInput.js
@@ -73,8 +73,13 @@ export default function AddressSearchInput({
     setSuggestions([]);
   }
 
+  const containerStyle = {
+    position: 'relative',
+    zIndex: suggestions.length > 0 ? 1000 : 100,
+  };
+
   return (
-    <View style={{ position: 'relative', zIndex: 100 }}>
+    <View style={containerStyle}>
       <View style={{ flexDirection: 'row', alignItems: 'center' }}>
         <AppInput
           placeholder={placeholder}


### PR DESCRIPTION
## Summary
- ensure the suggestions dropdown is displayed on top when typing a city

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68662edc5ac88324b602480305a742f9