### PR TITLE
Add radius-based order search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ npm run seed
 npm run dev
 ```
 
+## Searching for Nearby Orders
+
+The `GET /orders` endpoint now supports geographic search by radius.
+Provide `lat`, `lon` and `radius` (in kilometers) query parameters to
+retrieve orders whose pickup point is within the specified distance.
+If coordinates are omitted but a `city` is supplied, the service will
+geocode the city name using OpenStreetMap.
+


### PR DESCRIPTION
## Summary
- extend `listAvailableOrders` to accept `lat`, `lon` and `radius` parameters
- perform optional geocoding via OpenStreetMap when only a city is provided
- filter results using a haversine distance check
- document the new search options in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686632c47f74832484500d3b0b792d6e