### PR TITLE
Simplify radius search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ npm run seed
 npm run dev
 ```
 
+## Searching for Nearby Orders
+
+The `GET /orders` endpoint accepts `lat`, `lon` and `radius` (in
+kilometers) query parameters. All orders with pickup coordinates inside
+the specified radius are returned. Coordinates are required – the
+service does not perform address geocoding for this filter.
+


### PR DESCRIPTION
## Summary
- remove geocoding from radius lookup in `listAvailableOrders`
- update documentation for search by coordinates only

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686632c47f74832484500d3b0b792d6e