### PR TITLE
Implement filter fixes

### DIFF
--- a/mobile-app/src/components/AddressSearchInput.js
+++ b/mobile-app/src/components/AddressSearchInput.js
@@ -34,19 +34,7 @@ export default function AddressSearchInput({
         { headers: { 'User-Agent': 'vango-app' } }
       );
       const data = await res.json();
-      const allowed = ['city', 'town', 'village', 'hamlet', 'locality'];
-      const used = new Set();
-      const unique = [];
-      for (const item of data) {
-        if (!allowed.includes(item.type)) continue;
-        const addr = item.address || {};
-        const cityName = addr.city || addr.town || addr.village || addr.state || '';
-        if (cityName && !used.has(cityName)) {
-          used.add(cityName);
-          unique.push(item);
-        }
-      }
-      setSuggestions(unique);
+      setSuggestions(data);
     } catch {}
   }
 
@@ -69,7 +57,7 @@ export default function AddressSearchInput({
       postcode: addr.postcode || '',
     };
     onSelect(point);
-    onChangeText(cityName);
+    onChangeText(item.display_name);
     setSuggestions([]);
   }
 

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -20,8 +20,6 @@ export default function AllOrdersScreen({ navigation }) {
   const [date, setDate] = useState(new Date());
   const [pickupCity, setPickupCity] = useState('');
   const [pickupPoint, setPickupPoint] = useState(null);
-  const [dropoffCity, setDropoffCity] = useState('');
-  const [dropoffPoint, setDropoffPoint] = useState(null);
   const [volume, setVolume] = useState('');
   const [weight, setWeight] = useState('');
   const [orders, setOrders] = useState([]);
@@ -107,9 +105,10 @@ export default function AllOrdersScreen({ navigation }) {
     const useRadius = radius && origin && !isNaN(parseFloat(radius));
     if (!useRadius && pickupCity)
       params.append('pickupCity', pickupPoint?.city || pickupCity);
-    if (dropoffCity) params.append('dropoffCity', dropoffPoint?.city || dropoffCity);
-    if (volume) params.append('minVolume', volume);
-    if (weight) params.append('minWeight', weight);
+    const vol = parseNumber(volume);
+    if (!isNaN(vol)) params.append('maxVolume', vol);
+    const wt = parseNumber(weight);
+    if (!isNaN(wt)) params.append('maxWeight', wt);
     if (useRadius) {
       params.append('lat', origin.latitude);
       params.append('lon', origin.longitude);
@@ -145,9 +144,8 @@ export default function AllOrdersScreen({ navigation }) {
     if (o.reservedBy && o.reservedUntil && new Date(o.reservedUntil) > now) return false;
     if (date && formatDate(new Date(o.loadFrom)) !== formatDate(date)) return false;
     if (pickupCity && !(o.pickupCity || '').toLowerCase().includes(pickupCity.toLowerCase())) return false;
-    if (dropoffCity && !(o.dropoffCity || '').toLowerCase().includes(dropoffCity.toLowerCase())) return false;
-    if (volume && parseFloat(o.volume || 0) < parseFloat(volume)) return false;
-    if (weight && parseFloat(o.weight || 0) < parseFloat(weight)) return false;
+    if (volume && parseFloat(o.volume || 0) > parseNumber(volume)) return false;
+    if (weight && parseFloat(o.weight || 0) > parseNumber(weight)) return false;
     const origin = pickupPoint ? { latitude: parseFloat(pickupPoint.lat), longitude: parseFloat(pickupPoint.lon) } : location;
     if (radius && origin) {
       const r = parseFloat(radius);
@@ -171,9 +169,10 @@ export default function AllOrdersScreen({ navigation }) {
     const useRadius = radius && origin && !isNaN(parseFloat(radius));
     if (!useRadius && pickupCity)
       params.append('pickupCity', pickupPoint?.city || pickupCity);
-    if (dropoffCity) params.append('dropoffCity', dropoffPoint?.city || dropoffCity);
-    if (volume) params.append('minVolume', volume);
-    if (weight) params.append('minWeight', weight);
+    const vol = parseNumber(volume);
+    if (!isNaN(vol)) params.append('maxVolume', vol);
+    const wt = parseNumber(weight);
+    if (!isNaN(wt)) params.append('maxWeight', wt);
     if (useRadius) {
       params.append('lat', origin.latitude);
       params.append('lon', origin.longitude);
@@ -213,8 +212,6 @@ export default function AllOrdersScreen({ navigation }) {
     setDate(new Date());
     setPickupCity('');
     setPickupPoint(null);
-    setDropoffCity('');
-    setDropoffPoint(null);
     setVolume('');
     setWeight('');
     setRadius('30');
@@ -330,30 +327,15 @@ export default function AllOrdersScreen({ navigation }) {
             currentLocation={location}
             style={styles.input}
           />
-          <AddressSearchInput
-            placeholder="Місце розвантаження"
-            value={dropoffCity}
-            onChangeText={(t) => {
-              setDropoffCity(t);
-              if (!t) setDropoffPoint(null);
-            }}
-            onSelect={setDropoffPoint}
-            navigation={navigation}
-            onOpenMap={() => setFiltersVisible(false)}
-            onCloseMap={() => setFiltersVisible(true)}
-            lat={dropoffPoint?.lat}
-            lon={dropoffPoint?.lon}
-            style={styles.input}
-          />
           <AppInput
-            placeholder="Обʼєм м³"
+            placeholder="Обʼєм до м³"
             value={volume}
             onChangeText={setVolume}
             keyboardType="numeric"
             style={styles.input}
           />
           <AppInput
-            placeholder="Вага кг"
+            placeholder="Вага до кг"
             value={weight}
             onChangeText={setWeight}
             keyboardType="numeric"
@@ -421,6 +403,11 @@ function formatDate(d) {
   if (!d) return '';
   const pad = (n) => (n < 10 ? `0${n}` : n);
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function parseNumber(v) {
+  if (v === null || v === undefined) return NaN;
+  return parseFloat(String(v).replace(',', '.'));
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- remove dropoff city filter from `AllOrdersScreen`
- normalize weight and volume values before sending to API
- treat weight and volume inputs as maximum values
- clarify placeholders so users know filters are upper bounds
- search full addresses in pickup location filter

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686638e391708324b8179f9ae723f54e