### PR TITLE
Implement order highlight after map selection

### DIFF
--- a/mobile-app/src/components/OrderCard.js
+++ b/mobile-app/src/components/OrderCard.js
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import MapView, { Marker } from 'react-native-maps';
 import { colors } from './Colors';
 
-export default function OrderCard({ order, onPress }) {
+export default function OrderCard({ order, onPress, highlighted }) {
   const pickupCity = order.pickupCity || ((order.pickupLocation || '').split(',')[1] || '').trim();
   const dropoffCity = order.dropoffCity || ((order.dropoffLocation || '').split(',')[1] || '').trim();
   const volume = calcVolume(order.dimensions);
@@ -31,7 +31,7 @@ export default function OrderCard({ order, onPress }) {
   }
 
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, highlighted && styles.highlighted]}>
       <View style={styles.mapContainer}>
         <MapView style={{ flex: 1 }} initialRegion={region}>
 
@@ -104,6 +104,10 @@ const styles = StyleSheet.create({
     padding: 8,
     borderRadius: 8,
     elevation: 2,
+  },
+  highlighted: {
+    borderWidth: 2,
+    borderColor: colors.orange,
   },
   mapContainer: { height: 120, borderRadius: 8, overflow: 'hidden' },
   infoContainer: { paddingVertical: 4 },

--- a/mobile-app/src/screens/AllOrdersScreen.js
+++ b/mobile-app/src/screens/AllOrdersScreen.js
@@ -33,6 +33,8 @@ export default function AllOrdersScreen({ navigation }) {
   const sheetRef = useRef(null);
   const listRef = useRef(null);
   const mapRef = useRef(null);
+  const [highlightedId, setHighlightedId] = useState(null);
+  const highlightTimer = useRef(null);
 
   useEffect(() => {
     async function detectCity() {
@@ -90,6 +92,7 @@ export default function AllOrdersScreen({ navigation }) {
     connectWs();
     return () => {
       if (wsRef.current) wsRef.current.close();
+      if (highlightTimer.current) clearTimeout(highlightTimer.current);
     };
   }, [detected, token, location, pickupPoint]);
 
@@ -227,6 +230,7 @@ export default function AllOrdersScreen({ navigation }) {
     return (
       <OrderCard
         order={item}
+        highlighted={item.id === highlightedId}
         onPress={() => navigation.navigate('OrderDetail', { order: item, token })}
       />
     );
@@ -237,6 +241,9 @@ export default function AllOrdersScreen({ navigation }) {
     if (index >= 0 && listRef.current) {
       listRef.current.scrollToIndex({ index, animated: true });
     }
+    setHighlightedId(id);
+    if (highlightTimer.current) clearTimeout(highlightTimer.current);
+    highlightTimer.current = setTimeout(() => setHighlightedId(null), 3000);
     sheetRef.current?.expand();
   }
 


### PR DESCRIPTION
## Summary
- highlight order card when map marker is tapped
- auto clear highlight after a few seconds and scroll to the selected order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68663fc24cb083248a09783c440427f1