### PR TITLE
Fix Map Select confirm button width

### DIFF
--- a/mobile-app/src/components/AppButton.js
+++ b/mobile-app/src/components/AppButton.js
@@ -9,6 +9,7 @@ export default function AppButton({
   style,
   textStyle,
   disabled,
+  fullWidth = true,
   ...props
 }) {
   const bgColor =
@@ -25,6 +26,7 @@ export default function AppButton({
       backgroundColor: bgColor,
       opacity: disabled ? 0.4 : 1,
     },
+    fullWidth && { width: '100%' },
     pressed && { transform: [{ scale: 0.92 }] },
     style,
   ];
@@ -42,7 +44,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     justifyContent: 'center',
     alignItems: 'center',
-    width: '100%',
     marginVertical: 4,
   },
   text: {

--- a/mobile-app/src/screens/MapSelectScreen.js
+++ b/mobile-app/src/screens/MapSelectScreen.js
@@ -81,7 +81,12 @@ export default function MapSelectScreen({ navigation, route }) {
         <Ionicons name="arrow-back" size={32} color="#333" />
       </TouchableOpacity>
       {marker && (
-        <AppButton title="Підтвердити" onPress={confirm} style={styles.confirm} />
+        <AppButton
+          title="Підтвердити"
+          onPress={confirm}
+          style={styles.confirm}
+          fullWidth={false}
+        />
       )}
     </View>
   );


### PR DESCRIPTION
## Summary
- add `fullWidth` prop to `AppButton` component
- use `fullWidth={false}` in `MapSelectScreen`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686642fd49b0832484495a67570c62da