### PR TITLE
Use single cross platform date/time picker

### DIFF
--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -20,6 +20,7 @@
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.3",
+        "react-native-date-picker": "^5.0.13",
         "react-native-maps": "1.20.1"
       },
       "devDependencies": {
@@ -6807,6 +6808,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-date-picker": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/react-native-date-picker/-/react-native-date-picker-5.0.13.tgz",
+      "integrity": "sha512-qCLUODZVsJetO5zuoXjw1D39K527XWqBG8sOfhWdHyPzf13h8RXR1/RSKd1N0fdRDi5GdyizYmB0lPAK12/hbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3"
       }
     },
     "node_modules/react-native-edge-to-edge": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -9,19 +9,20 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "^7.5.0",
+    "@react-native-community/slider": "^5.0.0",
+    "@react-navigation/bottom-tabs": "^7.3.17",
     "@react-navigation/native": "^7.1.11",
     "@react-navigation/native-stack": "^7.3.16",
-    "@react-navigation/bottom-tabs": "^7.3.17",
-    "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~53.0.11",
+    "expo-image-picker": "^16.1.4",
+    "expo-location": "~18.1.5",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.3",
-    "expo-image-picker": "^16.1.4",
-    "@react-native-community/datetimepicker": "^7.5.0",
-    "@react-native-community/slider": "^5.0.0",
-    "react-native-maps": "1.20.1",
-    "expo-location": "~18.1.5"
+    "react-native-date-picker": "^5.0.13",
+    "react-native-maps": "1.20.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile-app/src/components/DateInput.js
+++ b/mobile-app/src/components/DateInput.js
@@ -1,54 +1,6 @@
-import React, { useState } from 'react';
-import { View, TouchableOpacity, Platform, StyleSheet } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import AppInput from './AppInput';
-import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import UniversalDateTimeInput from './UniversalDateTimeInput';
 
-export default function DateInput({ value, onChange, style, placeholder }) {
-
-  const [showDate, setShowDate] = useState(false);
-
-  function onChangeDate(_e, selected) {
-    setShowDate(false);
-    if (!selected) return;
-    const newDate = new Date(value);
-    newDate.setFullYear(selected.getFullYear(), selected.getMonth(), selected.getDate());
-    onChange(newDate);
-  }
-
-  return (
-    <View>
-      <TouchableOpacity onPress={() => setShowDate(true)}>
-        <View>
-          <AppInput
-            value={formatDate(value)}
-            placeholder={placeholder}
-            editable={false}
-            pointerEvents="none"
-            style={[{ paddingRight: 36, marginVertical: 0 }, style]}
-          />
-          <Ionicons name="calendar-outline" size={16} color="#000" style={styles.icon} />
-        </View>
-      </TouchableOpacity>
-      {showDate && (
-        <DateTimePicker
-          value={value}
-          mode="date"
-          is24Hour
-          display={Platform.OS === 'ios' ? 'inline' : 'default'}
-          onChange={onChangeDate}
-        />
-      )}
-    </View>
-  );
+export default function DateInput(props) {
+  return <UniversalDateTimeInput mode="date" {...props} />;
 }
-
-function formatDate(d) {
-  if (!d) return '';
-  const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
-}
-
-const styles = StyleSheet.create({
-  icon: { position: 'absolute', right: 12, top: 20 },
-});

--- a/mobile-app/src/components/DateTimeInput.js
+++ b/mobile-app/src/components/DateTimeInput.js
@@ -1,63 +1,6 @@
-import React, { useState } from 'react';
-import { View, TouchableOpacity, StyleSheet } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import AppInput from './AppInput';
+import React from 'react';
+import UniversalDateTimeInput from './UniversalDateTimeInput';
 
-export default function DateTimeInput({ value, onChange }) {
-  const [showDate, setShowDate] = useState(false);
-  const [showTime, setShowTime] = useState(false);
-
-  function onChangeDate(_e, selected) {
-    setShowDate(false);
-    if (!selected) return;
-    const newDate = new Date(value);
-    newDate.setFullYear(selected.getFullYear(), selected.getMonth(), selected.getDate());
-    onChange(newDate);
-  }
-
-  function onChangeTime(_e, selected) {
-    setShowTime(false);
-    if (!selected) return;
-    const newDate = new Date(value);
-    newDate.setHours(selected.getHours());
-    newDate.setMinutes(selected.getMinutes());
-    onChange(newDate);
-  }
-
-  return (
-    <View style={styles.row}>
-      <View style={{ flex: 1 }}>
-        <TouchableOpacity onPress={() => setShowDate(true)}>
-          <AppInput value={formatDate(value)} editable={false} pointerEvents="none" />
-        </TouchableOpacity>
-        {showDate && (
-          <DateTimePicker value={value} mode="date" is24Hour onChange={onChangeDate} />
-        )}
-      </View>
-      <View style={{ flex: 1 }}>
-        <TouchableOpacity onPress={() => setShowTime(true)}>
-          <AppInput value={formatTime(value)} editable={false} pointerEvents="none" />
-        </TouchableOpacity>
-        {showTime && (
-          <DateTimePicker value={value} mode="time" is24Hour onChange={onChangeTime} />
-        )}
-      </View>
-    </View>
-  );
+export default function DateTimeInput(props) {
+  return <UniversalDateTimeInput mode="datetime" {...props} />;
 }
-
-function formatDate(d) {
-  if (!d) return '';
-  const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-}
-
-function formatTime(d) {
-  if (!d) return '';
-  const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-const styles = StyleSheet.create({
-  row: { flexDirection: 'row', gap: 8 },
-});

--- a/mobile-app/src/components/TimeInput.js
+++ b/mobile-app/src/components/TimeInput.js
@@ -1,55 +1,6 @@
-import React, { useState } from 'react';
-import { View, TouchableOpacity, Platform, StyleSheet } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import AppInput from './AppInput';
-import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import UniversalDateTimeInput from './UniversalDateTimeInput';
 
-export default function TimeInput({ value, onChange, style, placeholder }) {
-
-  const [showTime, setShowTime] = useState(false);
-
-  function onChangeTime(_e, selected) {
-    setShowTime(false);
-    if (!selected) return;
-    const newDate = new Date(value);
-    newDate.setHours(selected.getHours());
-    newDate.setMinutes(selected.getMinutes());
-    onChange(newDate);
-  }
-
-  return (
-    <View>
-      <TouchableOpacity onPress={() => setShowTime(true)}>
-        <View>
-          <AppInput
-            value={formatTime(value)}
-            placeholder={placeholder}
-            editable={false}
-            pointerEvents="none"
-            style={[{ paddingRight: 36, marginVertical: 0 }, style]}
-          />
-          <Ionicons name="time-outline" size={16} color="#000" style={styles.icon} />
-        </View>
-      </TouchableOpacity>
-      {showTime && (
-        <DateTimePicker
-          value={value}
-          mode="time"
-          is24Hour
-          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-          onChange={onChangeTime}
-        />
-      )}
-    </View>
-  );
+export default function TimeInput(props) {
+  return <UniversalDateTimeInput mode="time" {...props} />;
 }
-
-function formatTime(d) {
-  if (!d) return '';
-  const pad = (n) => (n < 10 ? `0${n}` : n);
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-const styles = StyleSheet.create({
-  icon: { position: 'absolute', right: 12, top: 20 },
-});

--- a/mobile-app/src/components/UniversalDateTimeInput.js
+++ b/mobile-app/src/components/UniversalDateTimeInput.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import DatePicker from 'react-native-date-picker';
+import { Ionicons } from '@expo/vector-icons';
+import AppInput from './AppInput';
+
+export default function UniversalDateTimeInput({
+  value,
+  onChange,
+  mode = 'date',
+  placeholder,
+  style,
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View>
+      <TouchableOpacity onPress={() => setOpen(true)}>
+        <View>
+          <AppInput
+            value={format(value, mode)}
+            placeholder={placeholder}
+            editable={false}
+            pointerEvents="none"
+            style={[{ paddingRight: 36, marginVertical: 0 }, style]}
+          />
+          <Ionicons
+            name={mode === 'time' ? 'time-outline' : 'calendar-outline'}
+            size={16}
+            color="#000"
+            style={styles.icon}
+          />
+        </View>
+      </TouchableOpacity>
+      <DatePicker
+        modal
+        open={open}
+        date={value || new Date()}
+        mode={mode}
+        onConfirm={(date) => {
+          setOpen(false);
+          onChange(date);
+        }}
+        onCancel={() => setOpen(false)}
+      />
+    </View>
+  );
+}
+
+function format(d, mode) {
+  if (!d) return '';
+  const pad = (n) => (n < 10 ? `0${n}` : n);
+  const dateStr = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+  const timeStr = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  if (mode === 'date') return dateStr;
+  if (mode === 'time') return timeStr;
+  return `${dateStr} ${timeStr}`;
+}
+
+const styles = StyleSheet.create({
+  icon: { position: 'absolute', right: 12, top: 20 },
+});

--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -9,7 +9,6 @@ import {
 import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
 import AppButton from '../components/AppButton';
-import DateTimeInput from '../components/DateTimeInput';
 import DateInput from '../components/DateInput';
 import TimeInput from '../components/TimeInput';
 import { colors } from '../components/Colors';

--- a/mobile-app/src/screens/EditOrderScreen.js
+++ b/mobile-app/src/screens/EditOrderScreen.js
@@ -10,7 +10,6 @@ import {
 import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
 import AppButton from '../components/AppButton';
-import DateTimeInput from '../components/DateTimeInput';
 import DateInput from '../components/DateInput';
 import TimeInput from '../components/TimeInput';
 import { colors } from '../components/Colors';


### PR DESCRIPTION
## Summary
- add `react-native-date-picker` for consistent date/time selection
- create `UniversalDateTimeInput` abstraction
- refactor `DateInput`, `TimeInput` and `DateTimeInput` to reuse it
- remove unused DateTimeInput imports

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68666655c3c08324a9fb4717fe03e283