### PR TITLE
Fix order stream date parsing

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -116,28 +116,10 @@ async function listAvailableOrders(req, res) {
   if (dropoffCity) where.dropoffCity = dropoffCity;
 
   if (date) {
-    let parsed;
-    if (date.includes('.')) {
-      const parts = date.split('.');
-      if (parts.length === 2) {
-        const [d, m] = parts.map(Number);
-        if (!isNaN(d) && !isNaN(m)) {
-          const y = new Date().getFullYear();
-          parsed = new Date(y, m - 1, d);
-        }
-      } else if (parts.length === 3) {
-        const [d, m, y] = parts.map(Number);
-        if (!isNaN(d) && !isNaN(m) && !isNaN(y)) {
-          parsed = new Date(y, m - 1, d);
-        }
-      }
-    }
-    if (!parsed) {
-      const tmp = new Date(date);
-      if (!isNaN(tmp)) parsed = tmp;
-    }
+    const { parseDate } = require('../utils/date');
+    const parsed = parseDate(date);
     if (parsed) {
-      const start = parsed;
+      const start = new Date(parsed);
       const end = new Date(parsed);
       end.setDate(end.getDate() + 1);
       where.loadFrom = { [Op.gte]: start };

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,26 @@
+function parseDate(value) {
+  if (!value) return null;
+  let parsed;
+  if (typeof value === 'string' && value.includes('.')) {
+    const parts = value.split('.');
+    if (parts.length === 2) {
+      const [d, m] = parts.map(Number);
+      if (!isNaN(d) && !isNaN(m)) {
+        const y = new Date().getFullYear();
+        parsed = new Date(y, m - 1, d);
+      }
+    } else if (parts.length === 3) {
+      const [d, m, y] = parts.map(Number);
+      if (!isNaN(d) && !isNaN(m) && !isNaN(y)) {
+        parsed = new Date(y, m - 1, d);
+      }
+    }
+  }
+  if (!parsed) {
+    const tmp = new Date(value);
+    if (!isNaN(tmp)) parsed = tmp;
+  }
+  return parsed || null;
+}
+
+module.exports = { parseDate };

--- a/src/ws.js
+++ b/src/ws.js
@@ -19,11 +19,15 @@ function buildWhere(query, userId, ignoreReserve = false) {
   if (city) where.pickupCity = city;
   if (query.dropoffCity) where.dropoffCity = query.dropoffCity;
   if (query.date) {
-    const start = new Date(query.date);
-    const end = new Date(query.date);
-    end.setDate(end.getDate() + 1);
-    where.loadFrom = { [Op.gte]: start };
-    where.loadTo = { [Op.lt]: end };
+    const { parseDate } = require('./utils/date');
+    const parsed = parseDate(query.date);
+    if (parsed) {
+      const start = new Date(parsed);
+      const end = new Date(parsed);
+      end.setDate(end.getDate() + 1);
+      where.loadFrom = { [Op.gte]: start };
+      where.loadTo = { [Op.lt]: end };
+    }
   }
   if (query.minWeight || query.maxWeight) {
     where.weight = {};


### PR DESCRIPTION
## Summary
- factor out shared date parsing helper
- use helper when filtering orders in REST and websocket endpoints

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b9a0cf6608324a8c9c9af78f1e7bb