### PR TITLE
Add push notifications for order reserves

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ToastProvider } from './src/components/Toast';
@@ -11,6 +12,10 @@ import MapSelectScreen from './src/screens/MapSelectScreen';
 import OrderDetailScreen from './src/screens/OrderDetailScreen';
 import EditOrderScreen from './src/screens/EditOrderScreen';
 import { navigationRef, navigate } from './src/navigationRef';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({ shouldShowAlert: true }),
+});
 
 const Stack = createNativeStackNavigator();
 
@@ -40,6 +45,14 @@ function RootNavigator() {
   );
 }
 export default function App() {
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      const id = response.notification.request.content.data.orderId;
+      if (id) navigate('OrderDetail', { id });
+    });
+    return () => sub.remove();
+  }, []);
+
   return (
     <ToastProvider>
       <AuthProvider>

--- a/mobile-app/src/AuthContext.js
+++ b/mobile-app/src/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { apiFetch } from './api';
+import { getPushToken } from './notifications';
 
 const AuthContext = createContext({});
 
@@ -70,6 +71,25 @@ export function AuthProvider({ children }) {
       }
     }
   };
+
+  useEffect(() => {
+    if (!token) return;
+    async function register() {
+      try {
+        const expoToken = await getPushToken();
+        if (expoToken) {
+          await apiFetch('/auth/push-token', {
+            method: 'PUT',
+            headers: { Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ token: expoToken }),
+          });
+        }
+      } catch (e) {
+        console.log('push token error', e.message);
+      }
+    }
+    register();
+  }, [token]);
 
   const logout = async () => {
     await AsyncStorage.multiRemove(['token', 'role']);

--- a/mobile-app/src/notifications.js
+++ b/mobile-app/src/notifications.js
@@ -1,0 +1,16 @@
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+
+export async function getPushToken() {
+  if (!Device.isDevice) return null;
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== 'granted') return null;
+  const { data } = await Notifications.getExpoPushTokenAsync();
+  return data;
+}
+

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -56,4 +56,12 @@ async function updateRole(req, res) {
   res.json({ role: req.user.role });
 }
 
-module.exports = { register, login, profile, updateRole };
+async function updatePushToken(req, res) {
+  const token = req.body && req.body.token;
+  if (!token) return res.status(400).send('Token required');
+  req.user.pushToken = token;
+  await req.user.save();
+  res.sendStatus(204);
+}
+
+module.exports = { register, login, profile, updateRole, updatePushToken };

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -263,6 +263,15 @@ async function reserveOrder(req, res) {
     order.reservedUntil = new Date(now.getTime() + 10 * 60000);
     await order.save();
     broadcastOrder(order);
+    if (order.customer && order.customer.pushToken) {
+      const { sendPush } = require('../utils/push');
+      sendPush(
+        order.customer.pushToken,
+        'Замовлення у резерві',
+        'Водій взяв ваше замовлення в резерв',
+        { orderId: order.id }
+      );
+    }
     res.json({
       order,
       phone: order.customer ? order.customer.phone : null,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -29,6 +29,7 @@ User.init(
     blocked: { type: DataTypes.BOOLEAN, defaultValue: false },
     city: { type: DataTypes.STRING },
     phone: { type: DataTypes.STRING },
+    pushToken: { type: DataTypes.STRING },
     balance: { type: DataTypes.FLOAT, defaultValue: 0 },
   },
   {

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { register, login, profile, updateRole } = require('../controllers/authController');
+const { register, login, profile, updateRole, updatePushToken } = require('../controllers/authController');
 const { authenticate } = require('../middlewares/auth');
 
 const router = Router();
@@ -7,5 +7,6 @@ router.post('/register', register);
 router.post('/login', login);
 router.get('/me', authenticate, profile);
 router.put('/role', authenticate, updateRole);
+router.put('/push-token', authenticate, updatePushToken);
 
 module.exports = router;

--- a/src/utils/push.js
+++ b/src/utils/push.js
@@ -1,0 +1,16 @@
+const { Expo } = require('expo-server-sdk');
+const expo = new Expo();
+
+async function sendPush(to, title, body, data = {}) {
+  if (!to || !Expo.isExpoPushToken(to)) return;
+  try {
+    await expo.sendPushNotificationsAsync([
+      { to, sound: 'default', title, body, data },
+    ]);
+  } catch (err) {
+    console.error('Failed to send push', err);
+  }
+}
+
+module.exports = { sendPush };
+


### PR DESCRIPTION
## Summary
- store Expo push tokens for users
- allow mobile app to register push tokens
- send push notification to customer when driver reserves an order
- open order screen on notification tap

## Testing
- `npm install`
- `npm run dev` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686ba920e92c8324bb1a569162632d57