### PR TITLE
Update iOS datetimepicker

### DIFF
--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
-        "@react-native-community/datetimepicker": "^7.5.0",
+        "@react-native-community/datetimepicker": "^8.4.2",
         "@react-native-community/slider": "^5.0.0",
         "@react-navigation/bottom-tabs": "^7.3.17",
         "@react-navigation/native": "^7.1.11",
@@ -2306,12 +2306,26 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.7.0.tgz",
-      "integrity": "sha512-nYzZy4DQLRFUzKJShWzRleCaebmCJfZ1lIcFmZgMXJoiVuGJNw3OIGHSWmHhPETh3OhP1RO3to882d7WmDIyrA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.2.tgz",
+      "integrity": "sha512-V/s+foBfjlWGV8MKdMhxugq0SPMtYqUEYlf+sMrKUUm5Gx3pA9Qoum2ZQUqBfI4A8kgaEPIGyG/YsNX7ycnNSA==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/slider": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "@react-native-community/datetimepicker": "^7.5.0",
+    "@react-native-community/datetimepicker": "^8.4.2",
     "@react-native-community/slider": "^5.0.0",
     "@react-navigation/bottom-tabs": "^7.3.17",
     "@react-navigation/native": "^7.1.11",


### PR DESCRIPTION
## Summary
- bump @react-native-community/datetimepicker to 8.4.2 for iOS build compatibility

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686baf513cec8324b7e13474f798994f