### PR TITLE
Remove debug logs and add push logging

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -118,7 +118,6 @@ async function listAvailableOrders(req, res) {
   if (date) {
     const { parseDate } = require('../utils/date');
     const parsed = parseDate(date);
-    console.log('[listAvailableOrders] date query=', date, 'parsed=', parsed);
     if (parsed) {
       const start = new Date(parsed);
       const end = new Date(parsed);
@@ -144,7 +143,6 @@ async function listAvailableOrders(req, res) {
       ],
     },
   ];
-  console.log('[listAvailableOrders] where=', JSON.stringify(where));
   const orders = await Order.findAll({ where });
 
   const centerLat = parseFloat(lat);

--- a/src/utils/push.js
+++ b/src/utils/push.js
@@ -2,8 +2,12 @@ const { Expo } = require('expo-server-sdk');
 const expo = new Expo();
 
 async function sendPush(to, title, body, data = {}) {
-  if (!to || !Expo.isExpoPushToken(to)) return;
+  if (!to || !Expo.isExpoPushToken(to)) {
+    console.log('Push not sent: invalid token', to);
+    return;
+  }
   try {
+    console.log('Sending push', { to, title, body, data });
     await expo.sendPushNotificationsAsync([
       { to, sound: 'default', title, body, data },
     ]);

--- a/src/ws.js
+++ b/src/ws.js
@@ -21,7 +21,6 @@ function buildWhere(query, userId, ignoreReserve = false) {
   if (query.date) {
     const { parseDate } = require('./utils/date');
     const parsed = parseDate(query.date);
-    console.log('[buildWhere] date query=', query.date, 'parsed=', parsed);
     if (parsed) {
       const start = new Date(parsed);
       const end = new Date(parsed);
@@ -47,7 +46,6 @@ function buildWhere(query, userId, ignoreReserve = false) {
       },
     ];
   }
-  console.log('[buildWhere] where=', JSON.stringify(where));
   return where;
 }
 


### PR DESCRIPTION
## Summary
- clean up leftover console logs from listing orders and websocket filter build
- add console logging to push notification helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9275f208324b253948dd24f8d26