### PR TITLE
Add push notification test button

### DIFF
--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -9,11 +9,13 @@ import { apiFetch } from '../api';
 import ListItem from '../components/ListItem';
 import { colors } from '../components/Colors';
 import ProfileCardSkeleton from '../components/ProfileCardSkeleton';
+import { useToast } from '../components/Toast';
 
 export default function SettingsScreen() {
   const { logout, role, selectRole, token } = useAuth();
   const [user, setUser] = useState(null);
   const [loadingProfile, setLoadingProfile] = useState(true);
+  const toast = useToast();
 
   useEffect(() => {
     async function load() {
@@ -43,6 +45,19 @@ export default function SettingsScreen() {
         setUser(me);
       } catch {}
       setLoadingProfile(false);
+    }
+  }
+
+  async function handleTestPush() {
+    console.log('Sending test push');
+    try {
+      await apiFetch('/auth/push-test', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      toast.show('Тестове сповіщення надіслано');
+    } catch (e) {
+      toast.show(e.message);
     }
   }
 
@@ -105,6 +120,7 @@ export default function SettingsScreen() {
           <RoleSwitch value={role} onChange={handleChange} />
         </ListItem>
       </View>
+      <AppButton title="Тест сповіщення" onPress={handleTestPush} style={styles.testButton} />
     </View>
   );
 }
@@ -192,6 +208,10 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     height: 48,
     justifyContent: 'center',
+  },
+  testButton: {
+    width: '100%',
+    marginTop: 16,
   },
   profileSwitch: {
     width: '100%',

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -64,4 +64,17 @@ async function updatePushToken(req, res) {
   res.sendStatus(204);
 }
 
-module.exports = { register, login, profile, updateRole, updatePushToken };
+async function testPush(req, res) {
+  if (!req.user.pushToken) return res.status(400).send('No push token');
+  const { sendPush } = require('../utils/push');
+  console.log('Test push requested by', req.user.id);
+  await sendPush(
+    req.user.pushToken,
+    'Test Notification',
+    'This is a test notification',
+    { test: true }
+  );
+  res.sendStatus(204);
+}
+
+module.exports = { register, login, profile, updateRole, updatePushToken, testPush };

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { register, login, profile, updateRole, updatePushToken } = require('../controllers/authController');
+const { register, login, profile, updateRole, updatePushToken, testPush } = require('../controllers/authController');
 const { authenticate } = require('../middlewares/auth');
 
 const router = Router();
@@ -8,5 +8,6 @@ router.post('/login', login);
 router.get('/me', authenticate, profile);
 router.put('/role', authenticate, updateRole);
 router.put('/push-token', authenticate, updatePushToken);
+router.post('/push-test', authenticate, testPush);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow requesting a test push from the server
- expose `POST /api/auth/push-test` endpoint
- add button on Settings screen to trigger test notification

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bc8f307088324b825acb26b3070a4