### PR TITLE
Add push notification consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,11 @@ notification to the current user. The endpoint logs the attempt on the
 server. In the mobile app, open **Settings** and tap **"Тест
 сповіщення"** to trigger this request.
 
+## Push Notification Consent
+
+Users must explicitly agree to receiving push notifications. Call
+`PUT /auth/push-consent` with `{ "consent": true }` in the request body
+to enable notifications for the current user. Pass `false` to revoke the
+consent.
+
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -64,10 +64,20 @@ async function updatePushToken(req, res) {
   res.sendStatus(204);
 }
 
+async function updatePushConsent(req, res) {
+  const consent = !!(req.body && req.body.consent);
+  req.user.pushConsent = consent;
+  await req.user.save();
+  res.json({ pushConsent: req.user.pushConsent });
+}
+
 async function testPush(req, res) {
   if (!req.user.pushToken) {
     console.log('Push test requested but no token for user', req.user.id);
     return res.status(400).send('No push token');
+  }
+  if (!req.user.pushConsent) {
+    return res.status(400).send('Push not allowed');
   }
   const { sendPush } = require('../utils/push');
   console.log('Test push requested by', req.user.id);
@@ -80,4 +90,12 @@ async function testPush(req, res) {
   res.sendStatus(204);
 }
 
-module.exports = { register, login, profile, updateRole, updatePushToken, testPush };
+module.exports = {
+  register,
+  login,
+  profile,
+  updateRole,
+  updatePushToken,
+  updatePushConsent,
+  testPush,
+};

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -261,7 +261,11 @@ async function reserveOrder(req, res) {
     order.reservedUntil = new Date(now.getTime() + 10 * 60000);
     await order.save();
     broadcastOrder(order);
-    if (order.customer && order.customer.pushToken) {
+    if (
+      order.customer &&
+      order.customer.pushToken &&
+      order.customer.pushConsent
+    ) {
       const { sendPush } = require('../utils/push');
       sendPush(
         order.customer.pushToken,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -30,6 +30,7 @@ User.init(
     city: { type: DataTypes.STRING },
     phone: { type: DataTypes.STRING },
     pushToken: { type: DataTypes.STRING },
+    pushConsent: { type: DataTypes.BOOLEAN, defaultValue: false },
     balance: { type: DataTypes.FLOAT, defaultValue: 0 },
   },
   {

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,5 +1,13 @@
 const { Router } = require('express');
-const { register, login, profile, updateRole, updatePushToken, testPush } = require('../controllers/authController');
+const {
+  register,
+  login,
+  profile,
+  updateRole,
+  updatePushToken,
+  updatePushConsent,
+  testPush,
+} = require('../controllers/authController');
 const { authenticate } = require('../middlewares/auth');
 
 const router = Router();
@@ -8,6 +16,7 @@ router.post('/login', login);
 router.get('/me', authenticate, profile);
 router.put('/role', authenticate, updateRole);
 router.put('/push-token', authenticate, updatePushToken);
+router.put('/push-consent', authenticate, updatePushConsent);
 router.post('/push-test', authenticate, testPush);
 
 module.exports = router;

--- a/src/seed.js
+++ b/src/seed.js
@@ -6,9 +6,32 @@ const Order = require('./models/order');
 async function seed() {
   await db.sync({ force: true });
 
-  const customer = await User.create({ name: 'Alice', email: 'alice@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC', phone: '380000000001' });
-  const driver = await User.create({ name: 'Bob', email: 'bob@example.com', password: 'pass', role: UserRole.BOTH, city: 'NYC', phone: '380000000002' });
-  await User.create({ name: 'Admin', email: 'admin@example.com', password: 'admin', role: UserRole.ADMIN, phone: '380000000003' });
+  const customer = await User.create({
+    name: 'Alice',
+    email: 'alice@example.com',
+    password: 'pass',
+    role: UserRole.BOTH,
+    city: 'NYC',
+    phone: '380000000001',
+    pushConsent: true,
+  });
+  const driver = await User.create({
+    name: 'Bob',
+    email: 'bob@example.com',
+    password: 'pass',
+    role: UserRole.BOTH,
+    city: 'NYC',
+    phone: '380000000002',
+    pushConsent: true,
+  });
+  await User.create({
+    name: 'Admin',
+    email: 'admin@example.com',
+    password: 'admin',
+    role: UserRole.ADMIN,
+    phone: '380000000003',
+    pushConsent: true,
+  });
 
   await Order.create({
     customerId: customer.id,


### PR DESCRIPTION
## Summary
- allow users to opt in to push notifications
- respect consent when sending notifications
- document the new `/auth/push-consent` endpoint

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bcfb2b6ac8324aec0aaeb8573ee99