### PR TITLE
feat: redirect to auth on session end

### DIFF
--- a/mobile-app/src/AuthContext.js
+++ b/mobile-app/src/AuthContext.js
@@ -1,7 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { apiFetch } from './api';
+import { apiFetch, setUnauthorizedHandler } from './api';
 import { getPushToken } from './notifications';
+import { navigate } from './navigationRef';
 
 const AuthContext = createContext({});
 
@@ -95,7 +96,12 @@ export function AuthProvider({ children }) {
     await AsyncStorage.multiRemove(['token', 'role']);
     setToken(null);
     setRole(null);
+    navigate('Login');
   };
+
+  useEffect(() => {
+    setUnauthorizedHandler(logout);
+  }, [logout]);
 
   const selectRole = async (r) => {
     if (!token) return;

--- a/mobile-app/src/api.js
+++ b/mobile-app/src/api.js
@@ -1,6 +1,12 @@
 export const HOST_URL = 'http://192.168.95.22:20004';
 export const API_URL = `${HOST_URL}/api`;
 
+let unauthorizedHandler;
+
+export function setUnauthorizedHandler(handler) {
+  unauthorizedHandler = handler;
+}
+
 export async function apiFetch(path, options = {}) {
   const headers = options.headers || {};
   if (!(options.body instanceof FormData)) {
@@ -10,6 +16,9 @@ export async function apiFetch(path, options = {}) {
     headers,
     ...options,
   });
+  if (res.status === 401 && unauthorizedHandler) {
+    unauthorizedHandler();
+  }
   if (!res.ok) {
     const error = await res.text();
     throw new Error(error);

--- a/mobile-app/src/screens/AnalyticsScreen.js
+++ b/mobile-app/src/screens/AnalyticsScreen.js
@@ -41,6 +41,8 @@ export default function AnalyticsScreen() {
       <Text>Average Price: {data.avgPrice}</Text>
       <Text>Delivered Orders: {data.deliveredCount}</Text>
       <Text>Average Delivery Time: {data.avgTime}</Text>
+      <Text>Active Sessions: {data.activeSessions}</Text>
+      <Text>Ended Sessions: {data.endedSessions}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- ensure unauthorized API responses trigger logout and navigation to login
- extend admin analytics with active and ended session counts
- show new analytics metrics in mobile app

## Testing
- `npm test`
- `cd mobile-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689333fb547c83249ec83bdcf4a54792