### PR TITLE
chore: enhance session end modal and rename analytics stats

### DIFF
--- a/mobile-app/src/AuthContext.js
+++ b/mobile-app/src/AuthContext.js
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { apiFetch, setUnauthorizedHandler } from './api';
 import { getPushToken } from './notifications';
 import { navigate } from './navigationRef';
-import { Modal, View, Text, StyleSheet, Button } from 'react-native';
+import { Modal, View, Text, StyleSheet } from 'react-native';
 
 
 const AuthContext = createContext({});
@@ -100,11 +100,10 @@ export function AuthProvider({ children }) {
     setToken(null);
     setRole(null);
     setShowLogoutModal(true);
-  };
-
-  const confirmLogout = () => {
-    setShowLogoutModal(false);
-    navigate('Login');
+    setTimeout(() => {
+      setShowLogoutModal(false);
+      navigate('Login');
+    }, 1500);
   };
 
   useEffect(() => {
@@ -132,8 +131,7 @@ export function AuthProvider({ children }) {
       <Modal visible={showLogoutModal} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={styles.modalBox}>
-            <Text style={styles.modalText}>Session ended. Please log in again.</Text>
-            <Button title="OK" onPress={confirmLogout} />
+            <Text style={styles.modalText}>Session ended. Redirecting to login…</Text>
           </View>
         </View>
       </Modal>
@@ -153,12 +151,16 @@ const styles = StyleSheet.create({
   modalBox: {
     backgroundColor: '#fff',
     padding: 24,
-    borderRadius: 8,
+    borderRadius: 12,
     width: '80%',
+    shadowColor: '#000',
+    shadowOpacity: 0.3,
+    shadowRadius: 10,
+    elevation: 5,
   },
   modalText: {
-    marginBottom: 16,
     textAlign: 'center',
     fontSize: 16,
+    fontWeight: '500',
   },
 });

--- a/mobile-app/src/screens/AnalyticsScreen.js
+++ b/mobile-app/src/screens/AnalyticsScreen.js
@@ -41,8 +41,8 @@ export default function AnalyticsScreen() {
       <Text style={styles.metric}>Average Price: {data.avgPrice}</Text>
       <Text style={styles.metric}>Delivered Orders: {data.deliveredCount}</Text>
       <Text style={styles.metric}>Average Delivery Time: {data.avgTime}</Text>
-      <Text style={styles.metric}>Active Sessions: {data.active_sessions}</Text>
-      <Text style={styles.metric}>End Sessions: {data.end_sessions}</Text>
+      <Text style={styles.metric}>Active Sessions: {data.activeSessions}</Text>
+      <Text style={styles.metric}>Ended Sessions: {data.endedSessions}</Text>
     </View>
   );
 }

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -44,17 +44,17 @@ async function analytics(_req, res) {
   const avgPrice = (await Order.sum('price')) / (await Order.count());
   const deliveredOrders = await Order.findAll({ where: { status: 'DELIVERED' } });
   const avgTime = deliveredOrders.length;
-  const active_sessions = await Order.count({
+  const activeSessions = await Order.count({
     where: {
       status: { [Op.notIn]: ['COMPLETED', 'DELIVERED', 'CANCELLED', 'REJECTED'] },
     },
   });
-  const end_sessions = await Order.count({
+  const endedSessions = await Order.count({
     where: {
       status: { [Op.in]: ['COMPLETED', 'DELIVERED', 'CANCELLED', 'REJECTED'] },
     },
   });
-  res.json({ avgPrice, deliveredCount: deliveredOrders.length, avgTime, active_sessions, end_sessions });
+  res.json({ avgPrice, deliveredCount: deliveredOrders.length, avgTime, activeSessions, endedSessions });
 }
 
 module.exports = { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics };


### PR DESCRIPTION
## Summary
- refine session end modal and auto-redirect to login
- rename analytics stats to camelCase across backend and app

## Testing
- `npm test`
- `cd mobile-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933db0ed848324890844471ec03f77