### PR TITLE
Improve logout modal messaging

### DIFF
--- a/mobile-app/src/AuthContext.js
+++ b/mobile-app/src/AuthContext.js
@@ -13,6 +13,7 @@ export function AuthProvider({ children }) {
   const [role, setRole] = useState(null);
   const [loading, setLoading] = useState(true);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [logoutMessage, setLogoutMessage] = useState('Session ended. Redirecting to login…');
 
   useEffect(() => {
     async function load() {
@@ -95,10 +96,15 @@ export function AuthProvider({ children }) {
     register();
   }, [token]);
 
-  const logout = async () => {
+  const logout = async (msg) => {
     await AsyncStorage.multiRemove(['token', 'role']);
     setToken(null);
     setRole(null);
+    const text =
+      typeof msg === 'string' && msg
+        ? msg.replace(/_/g, ' ')
+        : 'Session ended. Redirecting to login…';
+    setLogoutMessage(text);
     setShowLogoutModal(true);
     setTimeout(() => {
       setShowLogoutModal(false);
@@ -131,7 +137,7 @@ export function AuthProvider({ children }) {
       <Modal visible={showLogoutModal} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={styles.modalBox}>
-            <Text style={styles.modalText}>Session ended. Redirecting to login…</Text>
+            <Text style={styles.modalText}>{logoutMessage}</Text>
           </View>
         </View>
       </Modal>

--- a/mobile-app/src/api.js
+++ b/mobile-app/src/api.js
@@ -16,12 +16,12 @@ export async function apiFetch(path, options = {}) {
     headers,
     ...options,
   });
+  const text = await res.text();
   if (res.status === 401 && unauthorizedHandler) {
-    unauthorizedHandler();
+    unauthorizedHandler(text);
   }
   if (!res.ok) {
-    const error = await res.text();
-    throw new Error(error);
+    throw new Error(text);
   }
-  return res.json();
+  return text ? JSON.parse(text) : {};
 }


### PR DESCRIPTION
## Summary
- Display server-provided logout messages in modal with underscores converted to spaces
- Pass API 401 error text to unauthorized handler for custom logout messaging

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd mobile-app && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68935b3db4f8832499716faa7faceb99