### PR TITLE
feat: enforce light theme on login screen

### DIFF
--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, StatusBar } from 'react-native';
 
 import AppText from '../components/AppText';
 import AppInput from '../components/AppInput';
@@ -50,6 +50,7 @@ export default function LoginScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
+      <StatusBar barStyle="dark-content" backgroundColor="#fff" />
       <AppText style={styles.label}>Електронна пошта</AppText>
       <AppInput
         value={email}


### PR DESCRIPTION
## Summary
- force light theme on login page by setting StatusBar style to dark content

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68935f9481f08324abaddcd4018f70de