### PR TITLE
Style admin login page

### DIFF
--- a/frontend/src/AdminLogin.jsx
+++ b/frontend/src/AdminLogin.jsx
@@ -4,6 +4,7 @@ const AdminLogin = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const [messageType, setMessageType] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -16,33 +17,38 @@ const AdminLogin = () => {
       const data = await res.json();
       if (res.ok) {
         localStorage.setItem('token', data.token);
-        setMessage('Logged in');
+        setMessage('Вхід виконано');
+        setMessageType('success');
       } else {
-        setMessage(data.message || 'Login failed');
+        setMessage(data.message || 'Помилка входу');
+        setMessageType('error');
       }
     } catch (err) {
-      setMessage('Error connecting to server');
+      setMessage('Помилка з’єднання з сервером');
+      setMessageType('error');
     }
   };
 
   return (
-    <div>
-      <h2>Admin Login</h2>
-      <form onSubmit={handleSubmit}>
+    <div className="login-container">
+      <h2 className="login-title">Вхід адміністратора</h2>
+      <form className="login-form" onSubmit={handleSubmit}>
         <input
-          placeholder="Username"
+          className="login-input"
+          placeholder="Ім'я користувача"
           value={username}
           onChange={e => setUsername(e.target.value)}
         />
         <input
+          className="login-input"
           type="password"
-          placeholder="Password"
+          placeholder="Пароль"
           value={password}
           onChange={e => setPassword(e.target.value)}
         />
-        <button type="submit">Login</button>
+        <button className="login-button" type="submit">Увійти</button>
       </form>
-      {message && <p>{message}</p>}
+      {message && <p className={`login-message ${messageType}`}>{message}</p>}
     </div>
   );
 };

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,26 +1,68 @@
 body {
   margin: 0;
-  color: #fff;
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  background-image: linear-gradient(to bottom, #020917, #101725);
+  background-color: #f9fafb;
+  color: #273033;
 }
 
 .content {
   display: flex;
   min-height: 100vh;
-  line-height: 1.1;
-  text-align: center;
-  flex-direction: column;
   justify-content: center;
+  align-items: center;
 }
 
-.content h1 {
-  font-size: 3.6rem;
-  font-weight: 700;
+.login-container {
+  background: #fff;
+  padding: 32px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  max-width: 360px;
 }
 
-.content p {
-  font-size: 1.2rem;
-  font-weight: 400;
-  opacity: 0.5;
+.login-title {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-input {
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 1rem;
+}
+
+.login-button {
+  padding: 12px;
+  border: none;
+  border-radius: 6px;
+  background-color: #16a34a;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.login-button:hover {
+  background-color: #15803d;
+}
+
+.login-message {
+  margin-top: 16px;
+  text-align: center;
+}
+
+.login-message.success {
+  color: #16a34a;
+}
+
+.login-message.error {
+  color: #EF4444;
 }


### PR DESCRIPTION
## Summary
- restyle admin login with app-like inputs and buttons
- add success and error messaging

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b91544a30832483ced2afb9223210