### PR TITLE
Add admin push notification feature

### DIFF
--- a/backend-frontend/app.js
+++ b/backend-frontend/app.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const cors = require('cors');
 const authRouter = require('./routes/auth');
+const pushRouter = require('./routes/push');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(authRouter);
+app.use(pushRouter);
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => console.log(`Admin backend running on port ${PORT}`));

--- a/backend-frontend/routes/push.js
+++ b/backend-frontend/routes/push.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+
+// Forwards push notifications to the main application server
+router.post('/push', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'message is required' });
+  }
+  try {
+    const response = await fetch('http://localhost:3000/api/admin/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-admin-secret': process.env.ADMIN_SECRET || 'secret',
+      },
+      body: JSON.stringify({ message }),
+    });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to send push' });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/AdminLogin.jsx
+++ b/frontend/src/AdminLogin.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const AdminLogin = () => {
+const AdminLogin = ({ onLogin }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
@@ -17,6 +17,7 @@ const AdminLogin = () => {
       const data = await res.json();
       if (res.ok) {
         localStorage.setItem('token', data.token);
+        onLogin(data.token);
         setMessage('Вхід виконано');
         setMessageType('success');
       } else {

--- a/frontend/src/AdminMenu.jsx
+++ b/frontend/src/AdminMenu.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+const AdminMenu = ({ token, onLogout }) => {
+  const [text, setText] = useState('');
+  const [status, setStatus] = useState('');
+
+  const sendPush = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('http://localhost:4000/push', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus('Повідомлення надіслано');
+        setText('');
+      } else {
+        setStatus(data.error || 'Помилка надсилання');
+      }
+    } catch {
+      setStatus('Помилка сервера');
+    }
+  };
+
+  return (
+    <div className="menu-container">
+      <h2>Адмін панель</h2>
+      <form className="push-form" onSubmit={sendPush}>
+        <textarea
+          className="push-input"
+          placeholder="Текст push-повідомлення"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button className="push-button" type="submit">Надіслати push</button>
+      </form>
+      {status && <p className="push-status">{status}</p>}
+      <button className="logout-button" onClick={onLogout}>Вийти</button>
+    </div>
+  );
+};
+
+export default AdminMenu;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,23 @@
+import { useState } from 'react';
 import './App.css';
 import AdminLogin from './AdminLogin.jsx';
+import AdminMenu from './AdminMenu.jsx';
 
 const App = () => {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
   return (
     <div className="content">
-      <AdminLogin />
+      {token ? (
+        <AdminMenu token={token} onLogout={handleLogout} />
+      ) : (
+        <AdminLogin onLogin={setToken} />
+      )}
     </div>
   );
 };

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const { authenticate, authorize } = require('../middlewares/auth');
-const { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics } = require('../controllers/adminController');
+const { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics, sendPush } = require('../controllers/adminController');
 const { UserRole } = require('../models/user');
 
 const router = Router();
@@ -10,5 +10,12 @@ router.post('/drivers/:id/block', authenticate, authorize([UserRole.ADMIN]), blo
 router.post('/drivers/:id/unblock', authenticate, authorize([UserRole.ADMIN]), unblockDriver);
 router.post('/service-fee', authenticate, authorize([UserRole.ADMIN]), updateServiceFee);
 router.get('/analytics', authenticate, authorize([UserRole.ADMIN]), analytics);
+router.post('/push', (req, res) => {
+  const secret = req.headers['x-admin-secret'];
+  if (secret !== (process.env.ADMIN_SECRET || 'secret')) {
+    return res.status(403).send('Доступ заборонено');
+  }
+  return sendPush(req, res);
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- show admin menu after login with form to send push notifications
- forward push requests through admin backend to main server
- broadcast push messages to all users with tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend-frontend && npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba0581a748324967134353a7bc160