### PR TITLE
Auto-fetch shared admin secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Backend API for a logistics service mobile app using Node.js, Express and Postgr
 npm install
 ```
 
-2. Configure environment variables by copying `.env.example` to `.env` and setting values.
+2. Configure environment variables by copying `.env.example` to `.env` and setting values. In addition to `JWT_SECRET`, define `ADMIN_SECRET` shared by the admin backend and main server to authorize push requests between servers.
 
 3. Run database migrations and seed basic data:
 ```bash

--- a/backend-frontend/.env.example
+++ b/backend-frontend/.env.example
@@ -1,2 +1,4 @@
 JWT_SECRET=changeme
+APP_SERVER_URL=http://localhost:3000
+ADMIN_SECRET=changeme
 PORT=4000

--- a/backend-frontend/app.js
+++ b/backend-frontend/app.js
@@ -1,11 +1,37 @@
+require('dotenv').config();
+
 const express = require('express');
 const cors = require('cors');
 const authRouter = require('./routes/auth');
+const pushRouter = require('./routes/push');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(authRouter);
+app.use(pushRouter);
 
 const PORT = process.env.PORT || 4000;
-app.listen(PORT, () => console.log(`Admin backend running on port ${PORT}`));
+
+async function fetchAdminSecret() {
+  try {
+    const res = await fetch(
+      `${process.env.APP_SERVER_URL || 'http://localhost:3000'}/api/admin/secret`
+    );
+    if (res.ok) {
+      const { secret } = await res.json();
+      if (secret) {
+        process.env.ADMIN_SECRET = secret;
+        console.log('Loaded admin secret');
+      }
+    } else {
+      console.error('Failed to fetch admin secret:', res.status);
+    }
+  } catch (err) {
+    console.error('Failed to fetch admin secret', err);
+  }
+}
+
+fetchAdminSecret().finally(() => {
+  app.listen(PORT, () => console.log(`Admin backend running on port ${PORT}`));
+});

--- a/backend-frontend/routes/push.js
+++ b/backend-frontend/routes/push.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+
+// Forwards push notifications from the admin UI to the main application server.
+router.post('/push', async (req, res) => {
+  // Verify admin JWT
+  const auth = req.headers.authorization || '';
+  const token = auth.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const role = String(decoded.role || '').toUpperCase();
+    if (role !== 'ADMIN') return res.status(403).json({ error: 'Forbidden' });
+  } catch {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'message is required' });
+  }
+
+  try {
+    const upstream = await fetch(
+      `${process.env.APP_SERVER_URL || 'http://localhost:3000'}/api/admin/push`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: auth,
+          'x-admin-secret': process.env.ADMIN_SECRET || 'secret',
+        },
+        body: JSON.stringify({ message }),
+      }
+    );
+
+    const text = await upstream.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      data = { error: text };
+    }
+
+    if (!upstream.ok) {
+      return res
+        .status(upstream.status)
+        .json(data.error ? { error: data.error } : { error: upstream.statusText });
+    }
+
+    res.json(data);
+  } catch (err) {
+    console.error('Error forwarding push notification', err);
+    const message = err.cause?.message || err.message || 'Failed to send push';
+    res.status(500).json({ error: message });
+  }
+});
+
+module.exports = router;
+

--- a/frontend/src/AdminLogin.jsx
+++ b/frontend/src/AdminLogin.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const AdminLogin = () => {
+const AdminLogin = ({ onLogin }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
@@ -17,6 +17,7 @@ const AdminLogin = () => {
       const data = await res.json();
       if (res.ok) {
         localStorage.setItem('token', data.token);
+        onLogin(data.token);
         setMessage('Вхід виконано');
         setMessageType('success');
       } else {

--- a/frontend/src/AdminMenu.jsx
+++ b/frontend/src/AdminMenu.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+const AdminMenu = ({ token, onLogout }) => {
+  const [text, setText] = useState('');
+  const [status, setStatus] = useState('');
+
+  const sendPush = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('http://localhost:4000/push', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus('Повідомлення надіслано');
+        setText('');
+      } else {
+        setStatus(data.error || 'Помилка надсилання');
+      }
+    } catch {
+      setStatus('Помилка сервера');
+    }
+  };
+
+  return (
+    <div className="menu-container">
+      <h2>Адмін панель</h2>
+      <form className="push-form" onSubmit={sendPush}>
+        <textarea
+          className="push-input"
+          placeholder="Текст push-повідомлення"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button className="push-button" type="submit">Надіслати push</button>
+      </form>
+      {status && <p className="push-status">{status}</p>}
+      <button className="logout-button" onClick={onLogout}>Вийти</button>
+    </div>
+  );
+};
+
+export default AdminMenu;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,23 @@
+import { useState } from 'react';
 import './App.css';
 import AdminLogin from './AdminLogin.jsx';
+import AdminMenu from './AdminMenu.jsx';
 
 const App = () => {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
   return (
     <div className="content">
-      <AdminLogin />
+      {token ? (
+        <AdminMenu token={token} onLogout={handleLogout} />
+      ) : (
+        <AdminLogin onLogin={setToken} />
+      )}
     </div>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const dotenv = require('dotenv');
 const path = require('path');
 const http = require('http');
+const crypto = require('crypto');
 const db = require('./config/db');
 const authRoutes = require('./routes/authRoutes');
 const orderRoutes = require('./routes/orderRoutes');
@@ -14,6 +15,11 @@ const Order = require('./models/order');
 const { Op } = require('sequelize');
 
 dotenv.config();
+
+// Generate a shared admin secret on startup if one isn't provided
+if (!process.env.ADMIN_SECRET) {
+  process.env.ADMIN_SECRET = crypto.randomBytes(32).toString('hex');
+}
 
 const app = express();
 app.use(express.json());

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -1,14 +1,31 @@
 const { Router } = require('express');
 const { authenticate, authorize } = require('../middlewares/auth');
-const { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics } = require('../controllers/adminController');
+const { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics, sendPush } = require('../controllers/adminController');
 const { UserRole } = require('../models/user');
 
 const router = Router();
+
+// Expose the dynamically generated admin secret for trusted internal services
+router.get('/secret', (req, res) => {
+  res.json({ secret: process.env.ADMIN_SECRET || '' });
+});
 
 router.get('/users', authenticate, authorize([UserRole.ADMIN]), listUsers);
 router.post('/drivers/:id/block', authenticate, authorize([UserRole.ADMIN]), blockDriver);
 router.post('/drivers/:id/unblock', authenticate, authorize([UserRole.ADMIN]), unblockDriver);
 router.post('/service-fee', authenticate, authorize([UserRole.ADMIN]), updateServiceFee);
 router.get('/analytics', authenticate, authorize([UserRole.ADMIN]), analytics);
+router.post(
+  '/push',
+  authenticate,
+  authorize([UserRole.ADMIN]),
+  (req, res) => {
+    const secret = req.headers['x-admin-secret'];
+    if (secret !== (process.env.ADMIN_SECRET || 'secret')) {
+      return res.status(403).send('Доступ заборонено');
+    }
+    return sendPush(req, res);
+  }
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Generate admin secret on main server startup and expose it via `/api/admin/secret`
- Admin backend retrieves the secret at startup for inter-service push authorization

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend-frontend && npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba0581a748324967134353a7bc160