### PR TITLE
Add helper script to automate admin push flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ npm run seed
 npm run dev
 ```
 
+## Sending Admin Push Notifications
+
+The `backend-frontend` service includes a helper script that logs in and
+forwards a push message to the main API. Set the admin credentials in the
+environment and provide the message to send:
+
+```bash
+cd backend-frontend
+ADMIN_USERNAME=<user> ADMIN_PASSWORD=<pass> npm run push -- "Test message"
+```
+
+The script obtains a JWT via `/login` and calls `/push` with the proper
+authorization headers so the notification is delivered successfully.
+
 ## Searching for Nearby Orders
 
 The `GET /orders` endpoint accepts `lat`, `lon` and `radius` (in

--- a/backend-frontend/package.json
+++ b/backend-frontend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "push": "node scripts/sendPush.js"
   },
   "keywords": [],
   "author": "",

--- a/backend-frontend/scripts/sendPush.js
+++ b/backend-frontend/scripts/sendPush.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const baseUrl = process.env.ADMIN_BACKEND_URL || 'http://localhost:4000';
+const username = process.env.ADMIN_USERNAME;
+const password = process.env.ADMIN_PASSWORD;
+const message = process.argv.slice(2).join(' ');
+
+if (!username || !password || !message) {
+  console.error('Usage: ADMIN_USERNAME=... ADMIN_PASSWORD=... node scripts/sendPush.js "message"');
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    const loginRes = await fetch(`${baseUrl}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (!loginRes.ok) {
+      const text = await loginRes.text();
+      console.error('Login failed:', text);
+      process.exit(1);
+    }
+    const { token } = await loginRes.json();
+    const pushRes = await fetch(`${baseUrl}/push`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ message })
+    });
+    const text = await pushRes.text();
+    try {
+      console.log(JSON.parse(text));
+    } catch {
+      console.log(text);
+    }
+  } catch (err) {
+    console.error('Unexpected error:', err.message);
+    process.exit(1);
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add CLI script that logs in and forwards push notifications to main API
- wire npm script for sending push messages
- document push helper usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix backend-frontend test` *(fails: Error: no test specified)*
- `node backend-frontend/scripts/sendPush.js` *(prints usage message)*

------
https://chatgpt.com/codex/tasks/task_e_689bb501736c8324a4723dabb561921b