### PR TITLE
Restrict rating feature to dispatcher, admin and team lead roles

### DIFF
--- a/mobile-app/src/screens/RateUserScreen.js
+++ b/mobile-app/src/screens/RateUserScreen.js
@@ -4,23 +4,37 @@ import { apiFetch } from '../api';
 import { useAuth } from '../AuthContext';
 
 export default function RateUserScreen({ route }) {
-  const { token } = useAuth();
+  const { token, role } = useAuth();
   const { toUserId, orderId } = route.params;
   const [rating, setRating] = useState('5');
   const [comment, setComment] = useState('');
+
+  const allowed = ['DISPATCHER', 'ADMIN', 'TEAMLEAD'];
+  if (!allowed.includes(role)) {
+    return (
+      <View style={styles.container}>
+        <Text>Доступ заборонено</Text>
+      </View>
+    );
+  }
 
   async function submit() {
     await apiFetch('/ratings', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ toUserId, orderId, rating: parseFloat(rating), comment })
+      body: JSON.stringify({ toUserId, orderId, rating: parseFloat(rating), comment }),
     });
   }
 
   return (
     <View style={styles.container}>
       <Text>Rating</Text>
-      <TextInput style={styles.input} value={rating} onChangeText={setRating} keyboardType="numeric" />
+      <TextInput
+        style={styles.input}
+        value={rating}
+        onChangeText={setRating}
+        keyboardType="numeric"
+      />
       <Text>Comment</Text>
       <TextInput style={styles.input} value={comment} onChangeText={setComment} />
       <Button title="Submit" onPress={submit} />

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -5,6 +5,8 @@ const UserRole = {
   DRIVER: 'DRIVER',
   CUSTOMER: 'CUSTOMER',
   ADMIN: 'ADMIN',
+  DISPATCHER: 'DISPATCHER',
+  TEAMLEAD: 'TEAMLEAD',
   BOTH: 'BOTH',
 };
 

--- a/src/routes/ratingRoutes.js
+++ b/src/routes/ratingRoutes.js
@@ -1,9 +1,15 @@
 const { Router } = require('express');
-const { authenticate } = require('../middlewares/auth');
+const { authenticate, authorize } = require('../middlewares/auth');
+const { UserRole } = require('../models/user');
 const { rateUser } = require('../controllers/ratingController');
 
 const router = Router();
 
-router.post('/', authenticate, rateUser);
+router.post(
+  '/',
+  authenticate,
+  authorize([UserRole.DISPATCHER, UserRole.ADMIN, UserRole.TEAMLEAD]),
+  rateUser
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add dispatcher and team lead roles to user model
- restrict rating API to dispatcher, admin and team lead
- gate RateUser screen behind dispatcher/admin/team lead roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mobile-app && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac6ab5a2408324bb55dffab727bc7e