### PR TITLE
Add pickup address report endpoint

### DIFF
--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -1,6 +1,14 @@
 const { Router } = require('express');
 const { authenticate, authorize } = require('../middlewares/auth');
-const { listUsers, blockDriver, unblockDriver, updateServiceFee, analytics, sendPush } = require('../controllers/adminController');
+const {
+  listUsers,
+  blockDriver,
+  unblockDriver,
+  updateServiceFee,
+  analytics,
+  sendPush,
+  pickupAddressReport,
+} = require('../controllers/adminController');
 const { UserRole } = require('../models/user');
 
 const router = Router();
@@ -15,6 +23,7 @@ router.post('/drivers/:id/block', authenticate, authorize([UserRole.ADMIN]), blo
 router.post('/drivers/:id/unblock', authenticate, authorize([UserRole.ADMIN]), unblockDriver);
 router.post('/service-fee', authenticate, authorize([UserRole.ADMIN]), updateServiceFee);
 router.get('/analytics', authenticate, authorize([UserRole.ADMIN]), analytics);
+router.get('/reports/pickup-address', authenticate, authorize([UserRole.ADMIN]), pickupAddressReport);
 router.post(
   '/push',
   authenticate,


### PR DESCRIPTION
## Summary
- add admin endpoint for pickup address report with optional date and city filters
- return combined click/order metrics for each pickup address
- wire up new report route under admin APIs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aca2b3aaec832494fad409d7ecbf82