### PR TITLE
Fix pickup address report time filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "expo-server-sdk": "^3.15.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "moment-timezone": "^0.5.48",
         "multer": "^1.4.5-lts.1",
         "pg": "^8.16.0",
         "pg-hstore": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-server-sdk": "^3.15.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "moment-timezone": "^0.5.48",
     "multer": "^1.4.5-lts.1",
     "pg": "^8.16.0",
     "pg-hstore": "^2.3.4",


### PR DESCRIPTION
## Summary
- count pickup address clicks and orders separately
- convert NY-local time range to UTC when filtering order counts
- include moment-timezone dependency for timezone handling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b82965883248b5626c252333a98