### PR TITLE
Fetch ranks and websocket after authorization

### DIFF
--- a/frontend/src/AdminMenu.jsx
+++ b/frontend/src/AdminMenu.jsx
@@ -1,8 +1,21 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { fetchUserRanks } from './api/ranks.js';
+import { connectOrdersStream } from './utils/socket.js';
 
 const AdminMenu = ({ token, onLogout }) => {
   const [text, setText] = useState('');
   const [status, setStatus] = useState('');
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    if (!token) return;
+    fetchUserRanks(token).catch(() => {});
+    wsRef.current = connectOrdersStream(token);
+    return () => {
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [token]);
 
   const sendPush = async (e) => {
     e.preventDefault();

--- a/frontend/src/api/ranks.js
+++ b/frontend/src/api/ranks.js
@@ -1,0 +1,12 @@
+export async function fetchUserRanks(token) {
+  if (!token) return null;
+  const res = await fetch('http://localhost:4000/api-v1/ratingGradations', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch ranks');
+  }
+  return res.json();
+}

--- a/frontend/src/utils/socket.js
+++ b/frontend/src/utils/socket.js
@@ -1,0 +1,5 @@
+export function connectOrdersStream(token) {
+  if (!token) return null;
+  const ws = new WebSocket(`ws://localhost:4000/api/orders/stream?token=${encodeURIComponent(token)}`);
+  return ws;
+}


### PR DESCRIPTION
## Summary
- fetch user ranks with auth token only when available
- open orders WebSocket after login

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ada1d854f083249ced0d76c2e4794c