### PR TITLE
fix: adjust pickup address report

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -54,8 +54,8 @@ async function pickupAddressReport(req, res) {
   const where = {};
   if (city) where.pickupCity = city;
 
-  // Filter orders by NY time range when provided
-  const orderWhere = { ...where };
+  // Filter orders only by NY time range when provided, ignoring city
+  const orderWhere = {};
   if (start || end) {
     orderWhere.createdAt = {};
     const tz = 'America/New_York';
@@ -63,7 +63,7 @@ async function pickupAddressReport(req, res) {
     if (end) orderWhere.createdAt[Op.lte] = moment.tz(end, tz).toDate();
   }
 
-  // Aggregate total clicks and orders for the period
+  // Aggregate total clicks (city scoped) and orders (time scoped) for the period
   const [clicks, orders] = await Promise.all([
     Order.count({ where }),
     Order.count({ where: orderWhere }),


### PR DESCRIPTION
## Summary
- decouple order count from city in pickup address report

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adac7e58dc8324ba040267e5287d01