### PR TITLE
fix: adjust pickup address report

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -51,21 +51,21 @@ async function analytics(_req, res) {
 
 async function pickupAddressReport(req, res) {
   const { start, end, city } = req.query;
-  const where = {};
-  if (city) where.pickupCity = city;
 
-  // Filter orders by NY time range when provided
-  const orderWhere = { ...where };
+  const clickWhere = {};
+  if (city) clickWhere.pickupCity = city;
+
+  const orderWhere = {};
   if (start || end) {
-    orderWhere.createdAt = {};
     const tz = 'America/New_York';
+    orderWhere.createdAt = {};
     if (start) orderWhere.createdAt[Op.gte] = moment.tz(start, tz).toDate();
     if (end) orderWhere.createdAt[Op.lte] = moment.tz(end, tz).toDate();
   }
 
-  // Aggregate total clicks and orders for the period
+  // clicks filtered by city, orders filtered only by NY time range
   const [clicks, orders] = await Promise.all([
-    Order.count({ where }),
+    Order.count({ where: clickWhere }),
     Order.count({ where: orderWhere }),
   ]);
 


### PR DESCRIPTION
## Summary
- separate city and time filters in pickup address report so orders ignore city

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adac7e58dc8324ba040267e5287d01