### PR TITLE
feat: add logging for pickup address report

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -65,6 +65,15 @@ async function pickupAddressReport(req, res) {
     orderWhere.createdAt = { [Op.between]: [from.toDate(), to.toDate()] };
   }
 
+  console.log('pickupAddressReport params', {
+    start,
+    end,
+    city,
+    idManager,
+    clickWhere,
+    orderWhere,
+  });
+
   const [clicks, stats] = await Promise.all([
     Order.count({ where: clickWhere }),
     Order.findOne({
@@ -76,8 +85,10 @@ async function pickupAddressReport(req, res) {
       raw: true,
     }),
 
-    
+
   ]);
+
+  console.log('pickupAddressReport stats', { clicks, stats });
 
   const orders = Number(stats?.count || 0);
   const lastCreated = stats?.lastCreated || null;


### PR DESCRIPTION
## Summary
- add console logging of request parameters and DB stats in pickup address report

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb2d7e598832497855c8952a3794e