### PR TITLE
feat: add logging for pickup address report

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -65,8 +65,20 @@ async function pickupAddressReport(req, res) {
     orderWhere.createdAt = { [Op.between]: [from.toDate(), to.toDate()] };
   }
 
+  console.log('pickupAddressReport params', {
+    start,
+    end,
+    city,
+    idManager,
+    clickWhere,
+    orderWhere,
+  });
+
   const [clicks, stats] = await Promise.all([
-    Order.count({ where: clickWhere }),
+    Order.count({
+      where: clickWhere,
+      logging: (sql) => console.log('pickupAddressReport SQL clicks', sql),
+    }),
     Order.findOne({
       attributes: [
         [fn('COUNT', col('*')), 'count'],
@@ -74,10 +86,13 @@ async function pickupAddressReport(req, res) {
       ],
       where: orderWhere,
       raw: true,
+      logging: (sql) => console.log('pickupAddressReport SQL orders', sql),
     }),
 
-    
+
   ]);
+
+  console.log('pickupAddressReport stats', { clicks, stats });
 
   const orders = Number(stats?.count || 0);
   const lastCreated = stats?.lastCreated || null;


### PR DESCRIPTION
## Summary
- add console logging of request parameters and DB stats in pickup address report
- log executed SQL queries for clicks and orders

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb2d7e598832497855c8952a3794e