### PR TITLE
Remove test notification button and optionalize cargo dimensions

### DIFF
--- a/mobile-app/src/screens/CreateOrderScreen.js
+++ b/mobile-app/src/screens/CreateOrderScreen.js
@@ -32,11 +32,11 @@ export default function CreateOrderScreen({ navigation }) {
   const [dropoffQuery, setDropoffQuery] = useState('');
   const [dropoff, setDropoff] = useState(null);
   const [dropoffSuggestions, setDropoffSuggestions] = useState([]);
-  const [length, setLength] = useState('');
-  const [width, setWidth] = useState('');
-  const [height, setHeight] = useState('');
-  const [weight, setWeight] = useState('');
-  const [volWeight, setVolWeight] = useState('0');
+  // const [length, setLength] = useState('');
+  // const [width, setWidth] = useState('');
+  // const [height, setHeight] = useState('');
+  // const [weight, setWeight] = useState('');
+  // const [volWeight, setVolWeight] = useState('0');
   const [loadHelp, setLoadHelp] = useState(false);
   const [unloadHelp, setUnloadHelp] = useState(false);
   const [payment, setPayment] = useState('cash');
@@ -76,13 +76,13 @@ export default function CreateOrderScreen({ navigation }) {
     calcPrice();
   }, [pickup, dropoff]);
 
-  useEffect(() => {
-    const l = parseFloat(length) || 0;
-    const w = parseFloat(width) || 0;
-    const h = parseFloat(height) || 0;
-    const v = l * w * h * 250;
-    setVolWeight(v.toFixed(2));
-  }, [length, width, height]);
+  // useEffect(() => {
+  //   const l = parseFloat(length) || 0;
+  //   const w = parseFloat(width) || 0;
+  //   const h = parseFloat(height) || 0;
+  //   const v = l * w * h * 250;
+  //   setVolWeight(v.toFixed(2));
+  // }, [length, width, height]);
 
   async function create() {
     try {
@@ -109,14 +109,14 @@ export default function CreateOrderScreen({ navigation }) {
         fd.append('city', pickup.city);
       }
       fd.append('cargoType', description);
-      fd.append('dimensions', `${length}x${width}x${height}`);
-      fd.append('weight', weight || '0');
+      // fd.append('dimensions', `${length}x${width}x${height}`);
+      // fd.append('weight', weight || '0');
       fd.append('loadFrom', loadFrom.toISOString());
       fd.append('loadTo', loadTo.toISOString());
       fd.append('unloadFrom', unloadFrom.toISOString());
       fd.append('unloadTo', unloadTo.toISOString());
       fd.append('insurance', 'false');
-      fd.append('volWeight', volWeight);
+      // fd.append('volWeight', volWeight);
       fd.append('loadHelp', loadHelp ? 'true' : 'false');
       fd.append('unloadHelp', unloadHelp ? 'true' : 'false');
       fd.append('payment', payment);
@@ -141,11 +141,11 @@ export default function CreateOrderScreen({ navigation }) {
       setDropoffQuery('');
       setDropoff(null);
       setDropoffSuggestions([]);
-      setLength('');
-      setWidth('');
-      setHeight('');
-      setWeight('');
-      setVolWeight('0');
+      // setLength('');
+      // setWidth('');
+      // setHeight('');
+      // setWeight('');
+      // setVolWeight('0');
       setLoadHelp(false);
       setUnloadHelp(false);
       setPayment('cash');
@@ -423,6 +423,7 @@ export default function CreateOrderScreen({ navigation }) {
         />
       </View>
 
+      {/*
       <View style={styles.section}>
         <Ionicons name="cube" size={20} color={colors.green} />
         <AppText style={styles.label}>Габарити (Д x Ш x В, м)</AppText>
@@ -438,6 +439,7 @@ export default function CreateOrderScreen({ navigation }) {
 
       <AppText style={styles.labelStandalone}>Об'ємна вага, кг</AppText>
       <AppInput value={volWeight} editable={false} />
+      */}
 
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginTop: 8, marginLeft: 24 }}>
         <CheckBox value={loadHelp} onChange={setLoadHelp} label="Завантаження" />
@@ -495,7 +497,7 @@ export default function CreateOrderScreen({ navigation }) {
 
 const styles = StyleSheet.create({
   container: { padding: 24 },
-  dim: { width: 88, textAlign: 'center', height: 88 },
+  // dim: { width: 88, textAlign: 'center', height: 88 },
   suggestionsBox: {
     backgroundColor: '#fff',
     borderRadius: 8,


### PR DESCRIPTION
## Summary
- add scrollable container to settings screen and drop test notification button
- comment out cargo size and weight inputs, making them optional for order creation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a4160f4832492a8391ac609a23c